### PR TITLE
Added MIME-Type guessing

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -4,6 +4,7 @@
 */
 var MemoryOutputFileSystem = require("webpack/lib/MemoryOutputFileSystem");
 var MemoryInputFileSystem = require("enhanced-resolve/lib/MemoryInputFileSystem");
+var mime = require("mime");
 
 // constructor for the middleware
 module.exports = function(compiler, options) {
@@ -127,8 +128,7 @@ module.exports = function(compiler, options) {
 			// server content
 			var content = fs.readFileSync(fsPath);
 			res.setHeader("Access-Control-Allow-Origin", "*"); // To support XHR, etc.
-			if(/\.js$/.test(filename))
-				res.setHeader("Content-Type", "text/javascript"); // No warning in Chrome.
+			res.setHeader("Content-Type", mime.lookup(fsPath));
 			if(options.headers) {
 				for(var name in options.headers) {
 					res.setHeader(name, options.headers[name]);

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
 	"name": "webpack-dev-middleware",
-	"version": "0.10.1",
+	"version": "0.10.2",
 	"author": "Tobias Koppers @sokra",
 	"description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
 	"peerDependencies": {
 		"webpack": "0.10.x"
 	},
 	"dependencies": {
-		"enhanced-resolve": "0.5.x"
+		"enhanced-resolve": "0.5.x",
+		"mime": "1.x"
 	},
 	"licenses": [
 		{


### PR DESCRIPTION
I've added the [mime](https://github.com/broofa/node-mime/)-module because some resources aren't displayed if the mime-type is missing (svg for instance).
