### PR TITLE
Ability to pass onBuild callback

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -82,7 +82,8 @@ module.exports = function(compiler, options) {
 
 	// start watching
 	if(!options.lazy) {
-		var watching = compiler.watch(options.watchDelay, function(err) {
+		var watching = compiler.watch(options.watchDelay, function(err, stats) {
+			if(options.onBuild) options.onBuild(err, stats);
 			if(err) throw err;
 		});
 	} else {


### PR DESCRIPTION
It's useful with gulp-based environment. I'm use webpack-dev-middleware along with custom express dev server and I want to push livereload once build is done.
