### PR TITLE
Add close support

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -155,6 +155,11 @@ module.exports = function(compiler, options) {
 	webpackDevMiddleware.invalidate = function() {
 		if(watching) watching.invalidate();
 	};
+	webpackDevMiddleware.close = function(callback) {
+		callback = callback || function(){};
+		if(watching) watching.close(callback);
+		else callback();
+	};
 
 	webpackDevMiddleware.fileSystem = fs;
 


### PR DESCRIPTION
Now that `Watching` can `close()`, it would be good to be able to do that from the middleware.
