### PR TITLE
add Content-Length header to response

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -150,6 +150,7 @@ module.exports = function(compiler, options) {
 			var content = fs.readFileSync(filename);
 			res.setHeader("Access-Control-Allow-Origin", "*"); // To support XHR, etc.
 			res.setHeader("Content-Type", mime.lookup(filename));
+			res.setHeader("Content-Length", content.length);
 			if(options.headers) {
 				for(var name in options.headers) {
 					res.setHeader(name, options.headers[name]);


### PR DESCRIPTION
When bundle is large, I download the script using XMLHttpRequest, so
that the download progress can be monitored.

During development, to test that this works requires that Content-Length
header be sent in the dev server.