### PR TITLE
use res.send instead of res.end to enable etag.

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -155,7 +155,7 @@ module.exports = function(compiler, options) {
 					res.setHeader(name, options.headers[name]);
 				}
 			}
-			res.end(content);
+			res.send(content);
 		}, req);
 	}
 


### PR DESCRIPTION
use res.send instead of res.end to enable etag.