### PR TITLE
support build into filesystem

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -15,7 +15,7 @@ module.exports = function(compiler, options) {
 
 	// store our files in memory
 	var files = {};
-	var fs = compiler.outputFileSystem = new MemoryFileSystem();
+	var fs = compiler.outputFileSystem = (options.useRealFileSystem && compiler.outputFileSystem) || new MemoryFileSystem();
 
 	compiler.plugin("done", function(stats) {
 		// We are now on valid state


### PR DESCRIPTION
Hi,

I notice the middleware will replace the outputFileSystem with an in-memory one. But sometimes i may want to build them into my static  directory so that i can write relative path to request the script while still benefit features (such as HMR) from the dev server.

```
<script src="/path/to/script.js"></script>
```

should we just add an option named: `useRealFileSystem`?