### PR TITLE
Use watchOptions instead of solely allowing watchDelay

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,11 @@ app.use(webpackMiddleware(webpack({
 	// switch into lazy mode
 	// that means no watching, but recompilation on every request
 
-	watchDelay: 300,
-	// delay after change (only lazy: false)
+	watchOptions: {
+		aggregateTimeout: 300,
+		poll: true
+	},
+	// watch options (only lazy: false)
 
 	publicPath: "/assets/",
 	// public path to bind the middleware to

--- a/middleware.js
+++ b/middleware.js
@@ -9,7 +9,13 @@ var mime = require("mime");
 // constructor for the middleware
 module.exports = function(compiler, options) {
 	if(!options) options = {};
-	if(options.watchDelay === undefined) options.watchDelay = 200;
+	if(typeof options.watchOptions === "undefined") options.watchOptions = {};
+	if(typeof options.watchDelay !== "undefined") {
+		// TODO remove this in next major version
+		console.warn("options.watchDelay is deprecated: Use 'options.watchOptions.aggregateTimeout' instead");
+		options.watchOptions.aggregateTimeout = options.watchDelay;
+	}
+	if(typeof options.watchOptions.aggregateTimeout === "undefined") options.watchOptions.aggregateTimeout = 200;
 	if(typeof options.stats === "undefined") options.stats = {};
 	if(!options.stats.context) options.stats.context = process.cwd();
 
@@ -81,7 +87,7 @@ module.exports = function(compiler, options) {
 
 	// start watching
 	if(!options.lazy) {
-		var watching = compiler.watch(options.watchDelay, function(err) {
+		var watching = compiler.watch(options.watchOptions, function(err) {
 			if(err) throw err;
 		});
 	} else {


### PR DESCRIPTION
Use case:

```js
watchOptions: {
  poll: true
}
```

in `webpack.config.js`.

This is analogous to the deprecation in the `webpack` CLI.

See https://github.com/webpack/webpack/blob/89058a2c4a32a2ec31c88acb3789c4f9eda58db1/bin/convert-argv.js#L84 and https://github.com/webpack/webpack/blob/89058a2c4a32a2ec31c88acb3789c4f9eda58db1/lib/webpack.js#L35