### PR TITLE
Rename watchDelay to watchOptions property of options

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -81,7 +81,7 @@ module.exports = function(compiler, options) {
 
 	// start watching
 	if(!options.lazy) {
-		var watching = compiler.watch(options.watchDelay, function(err) {
+		var watching = compiler.watch(options.watchOptions, function(err) {
 			if(err) throw err;
 		});
 	} else {


### PR DESCRIPTION
Webpack's `Compiler.watch` method now expects an object of configuration options as it's first argument, and *not* the watch delay parameter. The `watchOptions` object from the options passed here should be passed onto the webpack compiler.

Though a workaround for now is to pass the watch options configuration object as a property called `watchDelay`, it's very counter-intuitive and Webpack's documentation specifies the configuration file's property as "watchOptions" (see http://webpack.github.io/docs/configuration.html#watchoptions-aggregatetimeout).

This changed was added as of v1.9.1 here: https://github.com/webpack/webpack/commit/18f3595cdefd9682ca5dff55a6d3a9712985ec39

See https://github.com/webpack/webpack/blob/master/lib/Compiler.js#L160