### PR TITLE
Add progress support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ app.use(webpackMiddleware(webpack({
 	quiet: false,
 	// display nothing to the console
 
+	progress: false,
+  // show bundle build progress
+
 	lazy: true,
 	// switch into lazy mode
 	// that means no watching, but recompilation on every request

--- a/middleware.js
+++ b/middleware.js
@@ -5,6 +5,7 @@
 var path = require("path");
 var MemoryFileSystem = require("memory-fs");
 var mime = require("mime");
+var ProgressPlugin = require("webpack/lib/ProgressPlugin");
 
 // constructor for the middleware
 module.exports = function(compiler, options) {
@@ -65,6 +66,19 @@ module.exports = function(compiler, options) {
 			rebuild();
 		}
 	});
+
+	if (options.progress) {
+		compiler.apply(new ProgressPlugin(function(percentage, msg) {
+			var stream = process.stderr;
+			if (stream.isTTY && percentage < 0.71) {
+				stream.cursorTo(0);
+				stream.write(msg);
+				stream.clearLine(1);
+			} else if (percentage === 1) {
+				console.log('\nwebpack: bundle build is now finished.');
+			}
+		}));
+	}
 
 	// on compiling
 	function invalidPlugin() {


### PR DESCRIPTION
Hi, this package is very useful when develop with koa or expressjs.

But, every time server restart, there is a long time console do not output anything. When I use the grunt-webpack, there is progress message, that make me feel more speed.

So, I think this package need progress too.