### PR TITLE
changed usage of path.join to hardcoded string when requesting root directory on windows

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -155,7 +155,7 @@ module.exports = function(compiler, options) {
 				var stat = fs.statSync(filename);
 				if(!stat.isFile()) {
 					if (stat.isDirectory()) {
-						filename = path.join(filename, "index.html");
+						filename = "/index.html";
 						stat = fs.statSync(filename);
 						if(!stat.isFile()) throw "next";
 					} else {


### PR DESCRIPTION
On windows the file "index.html" is not being served correctly by memory-fs when requesting the root directory (ex. http://localhost:1377) because using path.join here throws an error on * https://github.com/webpack/memory-fs/blob/master/lib/MemoryFileSystem.js#L27 as "\index.html" is not considered a valid path.

This error gets caught at line 165 so in 170 no content is set, etc.

This change ensures the file gets served when requesting "/" on windows.