### PR TITLE
Include output path in file name pattern

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -23,7 +23,7 @@ module.exports = function(compiler, options) {
 			var str = options.filename
 				.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")
 				.replace(/\\\[[a-z]+\\\]/ig, ".+");
-			options.filename = new RegExp("^" + str + "$");
+			options.filename = new RegExp("^" + pathJoin(compiler.outputpath, str) + "$");
 		}
 	}
 


### PR DESCRIPTION
When the `lazy` option is set, the `filename` pattern is used to
determine which requests should trigger a reload. Because the string
being tested in that case includes the output path (see the
`getFilenameFromUrl` function), the matching pattern should also include
it.

Update the output path in the `filename` pattern so that the `lazy`
option correctly enables building on request.