### PR TITLE
Allow to customize `outputPath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ app.use(webpackMiddleware(webpack({
 	// public path to bind the middleware to
 	// use the same as in webpack
 
+	outputPath: __dirname + "/build/public",
+	// output path, in case it differs from the
+	// base output path set by MultiCompiler
+
 	headers: { "X-Custom-Header": "yes" },
 	// custom headers
 

--- a/middleware.js
+++ b/middleware.js
@@ -30,6 +30,7 @@ module.exports = function(compiler, options) {
 	// store our files in memory
 	var files = {};
 	var fs = compiler.outputFileSystem = new MemoryFileSystem();
+	var outputPath = typeof options.outputPath === "undefined" ? compiler.outputPath : options.outputPath;
 
 	compiler.plugin("done", function(stats) {
 		// We are now on valid state
@@ -137,7 +138,7 @@ module.exports = function(compiler, options) {
 		if(filename.indexOf("?") >= 0) {
 			filename = filename.substr(0, filename.indexOf("?"));
 		}
-		return filename ? pathJoin(compiler.outputPath, filename) : compiler.outputPath;
+		return filename ? pathJoin(outputPath, filename) : outputPath;
 	}
 
 	// The middleware function


### PR DESCRIPTION
Currently there is no way to make `webpack-dev-middleware` work with multiple compilers, where each compiler has its own `outputPath`.

For example, server-side bundle is written to `/build/server.js` and client-side bundle is written to `/build/public/client.js`. The current version of middleware tries to find `client.js` in the `/build` folder. Note that, Node.js app (`server.js`) serves static files from the `public` folder, e.g. there are links such as `<script src="/client.js">` and not `<script src="/public/client.js">`.

##### Usage sample:

```js
webpackDevMiddleware(compiler, {
  outputPath: path.join(__dirname, '../build/public');
});

```