### PR TITLE
Add API functions to wait until the state is valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,40 @@ app.use(webpackMiddleware(webpack({
 	// options for formating the statistics
 }));
 ```
+
+## Advanced API
+
+This part shows how you might interact with the middleware during runtime:
+
+* `close(callback)` - stop watching for file changes
+	```js
+	var webpackDevMiddlewareInstance = webpackMiddleware(/* see example usage */);
+	app.use(webpackDevMiddlewareInstance);
+	// After 10 seconds stop watching for file changes:
+	setTimeout(function(){
+	  webpackDevMiddlewareInstance.close();
+	}, 10000);
+	```
+
+* `invalidate()` - recompile the bundle - e.g. after you changed the configuration
+	```js
+	var compiler = webpack(/* see example usage */);
+	var webpackDevMiddlewareInstance = webpackMiddleware(compiler);
+	app.use(webpackDevMiddlewareInstance);
+	setTimeout(function(){
+	  // After a short delay the configuration is changed
+	  // in this example we will just add a banner plugin: 
+	  compiler.apply(new webpack.BannerPlugin('A new banner'));
+	  // Recompile the bundle with the banner plugin:
+	  webpackDevMiddlewareInstance.invalidate();
+	}, 1000);
+	```
+
+* `waitUntilValid(callback)` - executes the `callback` if the bundle is valid or after it is valid again:
+	```js
+	var webpackDevMiddlewareInstance = webpackMiddleware(/* see example usage */);
+	app.use(webpackDevMiddlewareInstance);
+	webpackDevMiddleware.waitUntilValid(function(){
+	  console.log('Package is in a valid state');
+	});
+	```

--- a/middleware.js
+++ b/middleware.js
@@ -182,9 +182,22 @@ module.exports = function(compiler, options) {
 
 	webpackDevMiddleware.getFilenameFromUrl = getFilenameFromUrl;
 
-	webpackDevMiddleware.invalidate = function() {
-		if(watching) watching.invalidate();
+	webpackDevMiddleware.waitUntilValid = function(callback) {
+		callback = callback || function(){};
+		if (!watching || !watching.running) callback();
+		else callbacks.push(callback);
 	};
+
+	webpackDevMiddleware.invalidate = function(callback) {
+		callback = callback || function(){};
+		if(watching) {
+			callbacks.push(callback);
+			watching.invalidate();
+		} else {
+			callback();
+		}
+	};
+
 	webpackDevMiddleware.close = function(callback) {
 		callback = callback || function(){};
 		if(watching) watching.close(callback);


### PR DESCRIPTION
This pull request adds a new function:
```js
webpackDevMiddleware.waitUntilValid(callback);
```
It allows to wait until the webpackDevMiddleware is in a valid state.

It also extends the `invalidate` function and allows to pass a callback.
```js
webpackDevMiddleware.invalidate(function() {
  console.log('Valid again');
});
```

Bonus - you can wait until the current compilation is complete and compile afterwards by combining them:

```js
webpackDevMiddleware.waitUntilValid(function(){
  webpackDevMiddleware.invalidate(function(){
    console.log('Valid again');
  });
});
```