### PR TITLE
feat(onUpdate): accept a callback as options.onUpdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ app.use(webpackMiddleware(webpack({
 	// switch into lazy mode
 	// that means no watching, but recompilation on every request
 
+	onUpdate: function(stats) { doWhateverWithStats(stats); },
+	// manually handle the stats from the last compilation
+	// can be combined with quiet and noInfo for full control over output
+
 	watchOptions: {
 		aggregateTimeout: 300,
 		poll: true

--- a/middleware.js
+++ b/middleware.js
@@ -40,6 +40,10 @@ module.exports = function(compiler, options) {
 		process.nextTick(function() {
 			// check if still in valid state
 			if(!state) return;
+
+            // make a callback with stats
+			if(typeof options.onUpdate === 'function') options.onUpdate(stats);
+
 			// print webpack output
 			var displayStats = (!options.quiet && options.stats !== false);
 			if(displayStats &&


### PR DESCRIPTION
If `options.onUpdate` is provided, it will be called with the `stats` results of the compilation on every build.

In combination with setting `options.quiet`, it allows the user to manually handle the logging of the stats.