### PR TITLE
Allow slash in filename regex

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -24,7 +24,7 @@ module.exports = function(compiler, options) {
 			var str = options.filename
 				.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")
 				.replace(/\\\[[a-z]+\\\]/ig, ".+");
-			options.filename = new RegExp("^" + str + "$");
+			options.filename = new RegExp("^[\/]{0,1}" + str + "$");
 		}
 	}
 


### PR DESCRIPTION
I started the `webpack-dev-server` in lazy mode with the following arguments `--lazy --iframe --progress --colors`. My webpack.config.js looks like this:

```
'use strict';

var path = require('path');

module.exports = {
    entry: [
        './app/index'
    ],
    output: {
        path: path.join(__dirname, 'build'),
        filename: 'bundle.js',
        publicPath: '/static/'
    }
};
```

I got 404 error for bundle.js. After some debugging it turned out that this expression `(!options.filename || options.filename.test(filename))` on line 150 evaluates to `false` because `filename` variable equals to "/bundle.js" (with a forward slash). So I changed options.filename regex to allow optional forward slash and everything works now correctly.
