### PR TITLE
Support Range requests commonly used by media

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -141,6 +141,34 @@ module.exports = function(compiler, options) {
 		return filename ? pathJoin(compiler.outputPath, filename) : compiler.outputPath;
 	}
 
+	function handleRangeHeaders(content, req, res) {
+		if (req.headers['Accept-Ranges']) res.setHeader('Accept-Ranges', 'bytes');
+		if (req.headers.range) {
+			var ranges = parseRange(content.length, req.headers.range);
+
+			// unsatisfiable
+			if (-1 == ranges) {
+				res.setHeader('Content-Range', 'bytes */' + content.length);
+				res.statusCode = 416;
+				return content;
+			}
+
+			// valid (syntactically invalid/multiple ranges are treated as a regular response)
+			if (-2 != ranges && ranges.length === 1) {
+				// Content-Range
+				res.statusCode = 206;
+				var length = content.length;
+				res.setHeader(
+					'Content-Range',
+					'bytes ' + ranges[0].start + '-' + ranges[0].end + '/' + length
+				);
+
+				content = content.slice(ranges[0].start, ranges[0].end + 1);
+			}
+		}
+		return content;
+	}
+
 	// The middleware function
 	function webpackDevMiddleware(req, res, next) {
 		var filename = getFilenameFromUrl(req.url);
@@ -178,6 +206,7 @@ module.exports = function(compiler, options) {
 
 			// server content
 			var content = fs.readFileSync(filename);
+			content = handleRangeHeaders(content, req, res);
 			res.setHeader("Access-Control-Allow-Origin", "*"); // To support XHR, etc.
 			res.setHeader("Content-Type", mime.lookup(filename));
 			res.setHeader("Content-Length", content.length);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "memory-fs": "~0.3.0",
-    "mime": "^1.3.4"
+    "mime": "^1.3.4",
+    "range-parser": "^1.0.3"
   },
   "licenses": [
     {


### PR DESCRIPTION
Seeking through media, such as audio and video, often leads a browser
to make range requests, in addition to other scenarios. Responding with
the full content instead of the requested range and can lead to
unexpected behaviour in a web application that in production will
otherwise work since the production server supports range requests.

- Depend on range-parser to parse range request headers
- Use source from the `send` npm package on responding to range
  requests https://github.com/pillarjs/send/blob/31ceb6aaf530152c29a1855bf3f9dbd86533303e/index.js#L551-L583