### PR TITLE
Update webpack dependency to support 2.1.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
   "peerDependencies": {
-    "webpack": ">=1.0.0 <3"
+    "webpack": "1 || ^2.1.0-beta"
   },
   "dependencies": {
     "memory-fs": "~0.3.0",


### PR DESCRIPTION
Mimicking the babel-loader package.json, update the webpack peer dependency to support the 2.1.0-beta.