### PR TITLE
Fix issue with browsersync

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -171,7 +171,7 @@ module.exports = function(compiler, options) {
 
 	// The middleware function
 	function webpackDevMiddleware(req, res, next) {
-		var filename = getFilenameFromUrl(req.path);
+		var filename = getFilenameFromUrl(req.path || req.url);
 		if (filename === false) return next();
 
 		// in lazy mode, rebuild on bundle request


### PR DESCRIPTION
Some middleware and servers only `req.url` and not `req.path`, such as browser-sync and hygienist-middleware. This will serve as a fallback in case req.path is not available.