### PR TITLE
added readme for native http server, made next optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,28 @@ app.use(webpackMiddleware(webpack({
 }));
 ```
 
+Or use with native HTTP server:
+
+``` javascript
+var http = require('http')
+var webpackDevMiddleware = require('webpack-dev-middleware')
+
+var webpackConfig = require('./webpack.config')
+var compiler = require('webpack')(webpackConfig)
+
+var webpackRoute = webpackDevMiddleware(compiler,{
+  publicPath: webpackConfig.output.publicPath
+})
+
+var server = http.createServer(function(req, res) {
+  if (req.url.indexOf(webpackConfig.output.publicPath) === 0) {
+    return webpackRoute(req, res)
+  }
+})
+
+server.listen(8000)
+```
+
 ## Advanced API
 
 This part shows how you might interact with the middleware during runtime:

--- a/middleware.js
+++ b/middleware.js
@@ -139,6 +139,7 @@ module.exports = function(compiler, options) {
 		if(filename.indexOf("?") >= 0) {
 			filename = filename.substr(0, filename.indexOf("?"));
 		}
+
 		return filename ? pathJoin(compiler.outputPath, filename) : compiler.outputPath;
 	}
 
@@ -173,7 +174,8 @@ module.exports = function(compiler, options) {
 	// The middleware function
 	function webpackDevMiddleware(req, res, next) {
 		var filename = getFilenameFromUrl(req.url);
-		if (filename === false) return next();
+
+		if (filename === false) return next && next();
 
 		// in lazy mode, rebuild on bundle request
 		if(options.lazy && (!options.filename || options.filename.test(filename)))
@@ -192,6 +194,7 @@ module.exports = function(compiler, options) {
 		function processRequest() {
 			try {
 				var stat = fs.statSync(filename);
+
 				if(!stat.isFile()) {
 					if (stat.isDirectory()) {
 						filename = pathJoin(filename, "index.html");
@@ -202,7 +205,7 @@ module.exports = function(compiler, options) {
 					}
 				}
 			} catch(e) {
-				return next();
+				return next && next();
 			}
 
 			// server content


### PR DESCRIPTION
Hi

I'm working on a project now that won't need express. I found that your middleware worked great on native http server and added some readme on how to use without express or any other router. I also made the next callback optional.

Regards
Simon 