### PR TITLE
Option to specify output encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,14 @@ app.use(webpackMiddleware(webpack({
 
 	stats: {
 		colors: true
-	}
+	},
 	// options for formating the statistics
+
+	encodingOptions: {
+		charset: 'UTF-8',
+		include: /.*/
+	}
+	// change encoding if you need something different than UTF-8
 }));
 ```
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "webpack": "1 || ^2.1.0-beta"
   },
   "dependencies": {
+    "encoding": "^0.1.12",
     "memory-fs": "~0.3.0",
     "mime": "^1.3.4",
     "range-parser": "^1.0.3"


### PR DESCRIPTION
I'm working on a legacy project adding some modules built in React. The problem is that the project has charset ISO-8859-1 and webpack-dev-middleware always serve assets with UTF-8 encoding.

Probably there isn't a lot of people with this requirement, but it's nice to have more control over this kind of things.