### PR TITLE
set statusCode to 200 to capable of koa 

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -216,6 +216,7 @@ module.exports = function(compiler, options) {
 					res.setHeader(name, options.headers[name]);
 				}
 			}
+			res.statusCode = 200;
 			if (res.send) res.send(content);
 			else res.end(content);
 		}


### PR DESCRIPTION
when I use koa to serve webpack-dev-middleware, it will always return 404

because this line
https://github.com/koajs/koa/blob/master/lib/application.js#L133

![image](https://cloud.githubusercontent.com/assets/5069410/15210854/c33aa326-186a-11e6-8b9d-be1a24523f73.png)
![image](https://cloud.githubusercontent.com/assets/5069410/15210864/cc218644-186a-11e6-93c1-8fbf1486d733.png)
![image](https://cloud.githubusercontent.com/assets/5069410/15210888/e753a87a-186a-11e6-96d4-60fddc3b4e01.png)

but body return normally(after rebuild assets, so url is different)
![image](https://cloud.githubusercontent.com/assets/5069410/15211116/1c710402-186c-11e6-8ca9-5dd6c0c4f15a.png)

