### PR TITLE
Only use middleware for 'GET' requests

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -172,6 +172,10 @@ module.exports = function(compiler, options) {
 
 	// The middleware function
 	function webpackDevMiddleware(req, res, next) {
+		if(req.method !== 'GET') {
+			return next();
+		}
+		
 		var filename = getFilenameFromUrl(req.url);
 		if (filename === false) return next();
 


### PR DESCRIPTION
Doesn't make sense to for the middleware on all routes.