### PR TITLE
Added the ability to use historyApiFallback

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# @AngularClass
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+insert_final_newline = false
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ app.use(webpackMiddleware(webpack({
 		colors: true
 	}
 	// options for formating the statistics
+	
+	historyApiFallback: {
+		index: "/"
+	}
+	// similar to webpack.config for historyApiFallback
 }));
 ```
 

--- a/middleware.js
+++ b/middleware.js
@@ -202,7 +202,12 @@ module.exports = function(compiler, options) {
 					}
 				}
 			} catch(e) {
-				return next();
+				if (options.historyApiFallback && options.historyApiFallback.index) {
+					filename = pathJoin(getFilenameFromUrl(options.historyApiFallback.index), 'index.html');
+				}
+				else {
+					return next();
+				}
 			}
 
 			// server content

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webpack-dev-middleware",
-  "version": "1.6.1",
-  "author": "Tobias Koppers @sokra",
+  "version": "1.6.2",
+  "author": "Tobias Koppers @sokra, Chris Weed",
   "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
   "peerDependencies": {
     "webpack": "1 || ^2.1.0-beta"
@@ -24,6 +24,6 @@
   "main": "middleware.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/webpack/webpack-dev-middleware.git"
+    "url": "https://github.com/Kikketer/webpack-dev-middleware.git"
   }
 }


### PR DESCRIPTION
Give users the ability to use the historyApiFallback similar to what's in the webpack.config file.  This simply uses the `stat` exception that's thrown and then uses the sent in `index` to render the index page.