### PR TITLE
Removing watching/watching.running check

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -265,8 +265,7 @@ module.exports = function(compiler, options) {
 
 	webpackDevMiddleware.waitUntilValid = function(callback) {
 		callback = callback || function() {};
-		if(!watching || !watching.running) callback();
-		else ready(callback, {});
+		ready(callback, {});
 	};
 
 	webpackDevMiddleware.invalidate = function(callback) {


### PR DESCRIPTION
Given that `state` should always have the correct value (if the bundle is valid
or not) then we should be able to use ready directly without checking the
watcher.

I also hit a bug where the watcher had running set to false while the bundle was
invalid, leading to a callback being executed immediately instead of waiting.

Fixes #107