### PR TITLE
Add a options to config the index file path

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -194,7 +194,7 @@ module.exports = function(compiler, options) {
 				var stat = fs.statSync(filename);
 				if(!stat.isFile()) {
 					if (stat.isDirectory()) {
-						filename = pathJoin(filename, "index.html");
+						filename = pathJoin(filename, options.index || "index.html");
 						stat = fs.statSync(filename);
 						if(!stat.isFile()) throw "next";
 					} else {


### PR DESCRIPTION
Current implement default to serve /index.html.

But in express it has express.static(app.get('appPath'), {index: 'landing/index.html'})

This achieve the same thing.