### PR TITLE
readme.md change: publicPath should be stated as required

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ app.use(webpackMiddleware(webpack({
 		// but it will work with other paths too.
 	}
 }), {
-	// all options optional
+	// publicPath is required, whereas all other options are optional 
 
 	noInfo: false,
 	// display no info to console (only warnings and errors)


### PR DESCRIPTION
publicPath should be stated as required, as also described on the webpack docs: [https://webpack.github.io/docs/webpack-dev-middleware.html](url)

I think this can avoid confusion for beginners. 