### PR TITLE
Support for server-side rendering 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: false
+language: node_js
+node_js:
+  - node
+script: npm run travis

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ app.use(webpackMiddleware(webpack({
 		// but it will work with other paths too.
 	}
 }), {
-	// publicPath is required, whereas all other options are optional 
+	// publicPath is required, whereas all other options are optional
 
 	noInfo: false,
 	// display no info to console (only warnings and errors)
@@ -70,6 +70,9 @@ app.use(webpackMiddleware(webpack({
 		colors: true
 	}
 	// options for formating the statistics
+
+	serverSideRender: false,
+	// Turn off the server-side rendering mode. See Server-Side Rendering part for more info.
 }));
 ```
 
@@ -109,3 +112,18 @@ This part shows how you might interact with the middleware during runtime:
 	  console.log('Package is in a valid state');
 	});
 	```
+
+## Server-Side Rendering
+In order to develop a server-side rendering application, we need access to the [`stats`](https://github.com/webpack/docs/wiki/node.js-api#stats), which is generated with the latest build.
+
+In the server-side rendering mode, __webpack-dev-middleware__ sets the `stat` to `res.locals.webpackStats`, then call `next()` to trigger the next middleware, where we can render pages and response to clients. During the webpack building process, all requests will be pending until the build is finished and the `stat` is available.
+
+```JavaScript
+app.use(webpackMiddleware(compiler, { serverSideRender: true })
+
+// The following middleware would not be invoked until the latest build is finished.
+app.use((req, res) => {
+  const  assetsByChunkName = res.locals.webpackStats.toJson().assetsByChunkName
+  // then use `assetsByChunkName` for server-sider rendering
+})
+```

--- a/middleware.js
+++ b/middleware.js
@@ -200,7 +200,7 @@ module.exports = function(compiler, options) {
 		var goNext = function() {
 			if (!options.serverSideRender) return next()
 			ready(function() {
-				res.webpackStats = webpackStats
+				res.locals.webpackStats = webpackStats
 				next()
 			}, req)
 		}

--- a/middleware.js
+++ b/middleware.js
@@ -53,7 +53,6 @@ module.exports = function(compiler, options) {
 	if(typeof options.reporter !== "function") options.reporter = defaultReporter;
 
 	// store our files in memory
-	var files = {};
 	var fs = compiler.outputFileSystem = new MemoryFileSystem();
 
 	compiler.plugin("done", function(stats) {

--- a/middleware.js
+++ b/middleware.js
@@ -59,6 +59,7 @@ module.exports = function(compiler, options) {
 		// We are now on valid state
 		state = true;
 		webpackStats = stats
+
 		// Do the stuff in nextTick, because bundle may be invalidated
 		// if a change happened while compiling
 		process.nextTick(function() {
@@ -197,8 +198,8 @@ module.exports = function(compiler, options) {
 
 	// The middleware function
 	function webpackDevMiddleware(req, res, next) {
-		var goNext = function() {
-			if (!options.serverSideRender) return next()
+		function goNext() {
+			if(!options.serverSideRender) return next()
 			ready(function() {
 				res.locals.webpackStats = webpackStats
 				next()


### PR DESCRIPTION
In order to use this middleware to develop a server-side rendering application, we need access to the [`stats`](https://github.com/webpack/docs/wiki/node.js-api#stats). This PR is aimed to give the access to consumers.

## How it works

```JavaScript
app.use(webpackMiddleware(compiler, { serverSideRender: true })
app.use((req, res) => {
  const  assetsByChunkName = res.locals.webpackStats.toJson().assetsByChunkName
  // then use `assetsByChunkName` for server-sider rendering
})
```
If `options.serverSideRender` is true, the __webpack-dev-middleware__ will set the `stat` object, which is generated by the latest build, to `res.locals`, then call `next()` to trigger the next middleware. 

During the webpack building process, all requests, inclusive of non-files request, will be pending until the build is finished.
