### PR TITLE
Instantiate MemoryFileSystem only once

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -54,13 +54,13 @@ module.exports = function(compiler, options) {
 
 	// store our files in memory
 	var fs;
-	if (options.fileSystem) {
+	if(options.fileSystem) {
 		fs = compiler.outputFileSystem = options.fileSystem;
 	} else {
 		// TODO: Probably have a config for this as well, e.g. something like:
 		// options.reuseMemoryFs
 		var isMemoryFs = compiler.outputFileSystem instanceof MemoryFileSystem;
-		if (isMemoryFs) {
+		if(isMemoryFs) {
 			fs = compiler.outputFileSystem;
 		} else {
 			fs = compiler.outputFileSystem = new MemoryFileSystem();

--- a/middleware.js
+++ b/middleware.js
@@ -53,7 +53,17 @@ module.exports = function(compiler, options) {
 	if(typeof options.reporter !== "function") options.reporter = defaultReporter;
 
 	// store our files in memory
-	var fs = compiler.outputFileSystem = new MemoryFileSystem();
+	var fs;
+	if (options.fileSystem) {
+		fs = compiler.outputFileSystem = options.fileSystem;
+	} else {
+		var isMemoryFs = compiler.outputFileSystem instanceof MemoryFileSystem;
+		if (isMemoryFs) {
+			fs = compiler.outputFileSystem;
+		} else {
+			fs = compiler.outputFileSystem = new MemoryFileSystem();
+		}
+	}
 
 	compiler.plugin("done", function(stats) {
 		// We are now on valid state

--- a/middleware.js
+++ b/middleware.js
@@ -54,17 +54,11 @@ module.exports = function(compiler, options) {
 
 	// store our files in memory
 	var fs;
-	if(options.fileSystem) {
-		fs = compiler.outputFileSystem = options.fileSystem;
+	var isMemoryFs = compiler.outputFileSystem instanceof MemoryFileSystem;
+	if(isMemoryFs) {
+		fs = compiler.outputFileSystem;
 	} else {
-		// TODO: Probably have a config for this as well, e.g. something like:
-		// options.reuseMemoryFs
-		var isMemoryFs = compiler.outputFileSystem instanceof MemoryFileSystem;
-		if(isMemoryFs) {
-			fs = compiler.outputFileSystem;
-		} else {
-			fs = compiler.outputFileSystem = new MemoryFileSystem();
-		}
+		fs = compiler.outputFileSystem = new MemoryFileSystem();
 	}
 
 	compiler.plugin("done", function(stats) {

--- a/middleware.js
+++ b/middleware.js
@@ -57,6 +57,8 @@ module.exports = function(compiler, options) {
 	if (options.fileSystem) {
 		fs = compiler.outputFileSystem = options.fileSystem;
 	} else {
+		// TODO: Probably have a config for this as well, e.g. something like:
+		// options.reuseMemoryFs
 		var isMemoryFs = compiler.outputFileSystem instanceof MemoryFileSystem;
 		if (isMemoryFs) {
 			fs = compiler.outputFileSystem;


### PR DESCRIPTION
I wasn't sure if I should open an issue or a pull request, but since I already made some changes, here goes.

I have perhaps a peculiar use case: I want to use the middleware for multiple express apps that would share a single compiler but otherwise be independent and listen on different ports and serve different index files that would include different bundles (webpack is configured with multiple entry points).

The problem arises because the middleware mutates the compiler.outputFileSystem property. When setting up multiple middlewares only the last one will be valid and the ones before will hold a reference to a memory fs that the compiler is not using to write files to.

My solution was to detect if the outputFileSystem already was a MemoryFileSystem and if it was, just not overwrite it but use the existing one for the middleware. An alternative approach would be to take an optional file system as an option and use that, and then every middleware instance could be passed in the same fs reference. But this requires installing memory-fs as a peer so for my quick-fix I didn't do it that way.

There must be a better way to achieve this, and I also may be misunderstanding something and doing everything horribly wrong. I need some feedback on this and if changes in this direction are wanted, will fix up the commits and the code.