### PR TITLE
Make log & warn functions replaceable

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -54,7 +54,7 @@ module.exports = function(compiler, options) {
 	}
 	if(typeof options.reporter !== "function") options.reporter = defaultReporter;
 	if(typeof options.log !== "function") options.log = console.log.bind(console);
-	if(typeof options.warn !== "function") option.warn = console.warn.bind(console);
+	if(typeof options.warn !== "function") options.warn = console.warn.bind(console);
 
 	// store our files in memory
 	var fs;

--- a/middleware.js
+++ b/middleware.js
@@ -22,13 +22,13 @@ var defaultReporter = function(reporterOptions) {
 			options.noInfo)
 			displayStats = false;
 		if(displayStats) {
-			console.log(stats.toString(options.stats));
+			options.log(stats.toString(options.stats));
 		}
 		if(!options.noInfo && !options.quiet) {
-			console.info("webpack: bundle is now VALID.");
+			options.log("webpack: bundle is now VALID.");
 		}
 	} else {
-		console.info("webpack: bundle is now INVALID.");
+		options.log("webpack: bundle is now INVALID.");
 	}
 };
 
@@ -38,7 +38,7 @@ module.exports = function(compiler, options) {
 	if(typeof options.watchOptions === "undefined") options.watchOptions = {};
 	if(typeof options.watchDelay !== "undefined") {
 		// TODO remove this in next major version
-		console.warn("options.watchDelay is deprecated: Use 'options.watchOptions.aggregateTimeout' instead");
+		options.warn("options.watchDelay is deprecated: Use 'options.watchOptions.aggregateTimeout' instead");
 		options.watchOptions.aggregateTimeout = options.watchDelay;
 	}
 	if(typeof options.watchOptions.aggregateTimeout === "undefined") options.watchOptions.aggregateTimeout = 200;
@@ -53,6 +53,8 @@ module.exports = function(compiler, options) {
 		}
 	}
 	if(typeof options.reporter !== "function") options.reporter = defaultReporter;
+	if(typeof options.log !== "function") options.log = console.log.bind(console);
+	if(typeof options.warn !== "function") option.warn = console.warn.bind(console);
 
 	// store our files in memory
 	var fs;
@@ -130,7 +132,7 @@ module.exports = function(compiler, options) {
 	function ready(fn, req) {
 		if(state) return fn();
 		if(!options.noInfo && !options.quiet)
-			console.log("webpack: wait until bundle finished: " + (req.url || fn.name));
+			options.log("webpack: wait until bundle finished: " + (req.url || fn.name));
 		callbacks.push(fn);
 	}
 

--- a/test/Reporter.test.js
+++ b/test/Reporter.test.js
@@ -29,7 +29,7 @@ describe("Reporter", function() {
 	};
 	beforeEach(function() {
 		plugins = {};
-		this.sinon.stub(console, 'log', console.log.bind(console));
+		this.sinon.stub(console, 'log');
 	});
 
 	describe("valid/invalid messages", function() {

--- a/test/Reporter.test.js
+++ b/test/Reporter.test.js
@@ -29,8 +29,7 @@ describe("Reporter", function() {
 	};
 	beforeEach(function() {
 		plugins = {};
-		this.sinon.stub(console, 'log');
-		this.sinon.stub(console, 'info');
+		this.sinon.stub(console, 'log', console.log.bind(console));
 	});
 
 	describe("valid/invalid messages", function() {
@@ -39,8 +38,8 @@ describe("Reporter", function() {
 
 			plugins.done(simpleStats);
 			setTimeout(function() {
-				should.strictEqual(console.info.callCount, 1);
-				should.strictEqual(console.info.calledWith("webpack: bundle is now VALID."), true);
+				should.strictEqual(console.log.callCount, 2);
+				should.strictEqual(console.log.calledWith("webpack: bundle is now VALID."), true);
 				done();
 			});
 		});
@@ -50,7 +49,7 @@ describe("Reporter", function() {
 
 			plugins.done(simpleStats);
 			setTimeout(function() {
-				should.strictEqual(console.info.callCount, 0);
+				should.strictEqual(console.log.callCount, 0);
 				done();
 			});
 		});
@@ -60,7 +59,7 @@ describe("Reporter", function() {
 
 			plugins.done(simpleStats);
 			setTimeout(function() {
-				should.strictEqual(console.info.callCount, 0);
+				should.strictEqual(console.log.callCount, 0);
 				done();
 			});
 		});
@@ -70,8 +69,8 @@ describe("Reporter", function() {
 			plugins.done(simpleStats);
 			plugins.invalid();
 			setTimeout(function() {
-				should.strictEqual(console.info.callCount, 1);
-				should.strictEqual(console.info.calledWith("webpack: bundle is now INVALID."), true);
+				should.strictEqual(console.log.callCount, 1);
+				should.strictEqual(console.log.calledWith("webpack: bundle is now INVALID."), true);
 				done();
 			});
 		});
@@ -82,7 +81,7 @@ describe("Reporter", function() {
 			plugins.done(simpleStats);
 			plugins.invalid();
 			setTimeout(function() {
-				should.strictEqual(console.info.callCount, 0);
+				should.strictEqual(console.log.callCount, 0);
 				done();
 			});
 		});
@@ -93,7 +92,7 @@ describe("Reporter", function() {
 			plugins.done(simpleStats);
 			plugins.invalid();
 			setTimeout(function() {
-				should.strictEqual(console.info.callCount, 0);
+				should.strictEqual(console.log.callCount, 0);
 				done();
 			});
 		});
@@ -117,7 +116,7 @@ describe("Reporter", function() {
 
 			plugins.done(stats);
 			setTimeout(function() {
-				should.strictEqual(console.log.callCount, 1);
+				should.strictEqual(console.log.callCount, 2);
 				should.strictEqual(console.log.calledWith(stats.toString()), true);
 				done();
 			});
@@ -128,7 +127,7 @@ describe("Reporter", function() {
 
 			plugins.done(stats);
 			setTimeout(function() {
-				should.strictEqual(console.log.callCount, 0);
+				should.strictEqual(console.log.callCount, 1);
 				done();
 			});
 		});


### PR DESCRIPTION
By allowing overrides of the functions used for logging, we can allow the output from this middleware to be processed according to the logging library used in the application.