### PR TITLE
Fix protocol-relative urls with `publicPath`

### DIFF
--- a/lib/GetFilenameFromUrl.js
+++ b/lib/GetFilenameFromUrl.js
@@ -5,7 +5,7 @@ function getFilenameFromUrl(publicPath, outputPath, url) {
 	var filename;
 
 	// localPrefix is the folder our bundle should be in
-	var localPrefix = urlParse(publicPath || "/");
+	var localPrefix = urlParse(publicPath || "/", false, true);
 	var urlObject = urlParse(url);
 
 	// publicPath has the hostname that is not the same as request url's, should fail

--- a/test/GetFilenameFromUrl.test.js
+++ b/test/GetFilenameFromUrl.test.js
@@ -79,6 +79,11 @@ describe("GetFilenameFromUrl", function() {
 				outputPath: "/",
 				publicPath: "http://other.domain/test/",
 				expected: false
+			}, {
+				url: "/protocol/relative/sample.js",
+				outputPath: "/",
+				publicPath: "//test.domain/protocol/relative/",
+				expected: "/sample.js"
 			}
 		];
 		results.forEach(testUrl);


### PR DESCRIPTION
Pass `true` for `slashesDenoteHost` in `url.parse`.

https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost

Fixes #128