### PR TITLE
Add a option, mimeTypes, to support defining custom mime types

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ app.use(webpackMiddleware(webpack({
 	headers: { "X-Custom-Header": "yes" },
 	// custom headers
 
+	mimeTypes: { "text/html": [ "phtml" ] },
+	// Add custom mime/extension mappings
+	// https://github.com/broofa/node-mime#mimedefine
+	// https://github.com/webpack/webpack-dev-middleware/pull/150
+
 	stats: {
 		colors: true
 	}

--- a/lib/Shared.js
+++ b/lib/Shared.js
@@ -1,3 +1,4 @@
+var mime = require("mime");
 var parseRange = require("range-parser");
 var pathIsAbsolute = require("path-is-absolute");
 var MemoryFileSystem = require("memory-fs");
@@ -28,6 +29,9 @@ module.exports = function Shared(context) {
 					options.filename = new RegExp("^[\/]{0,1}" + str + "$");
 				}
 			}
+			// defining custom MIME type
+			if(options.mimeTypes) mime.define(options.mimeTypes);
+
 			context.options = options;
 		},
 		defaultReporter: function(reporterOptions) {

--- a/middleware.js
+++ b/middleware.js
@@ -21,6 +21,9 @@ module.exports = function(compiler, options) {
 	};
 	var shared = Shared(context);
 
+	if(options.mimeTypes) {
+		mime.define(options.mimeTypes);
+	}
 
 	// The middleware function
 	function webpackDevMiddleware(req, res, next) {

--- a/middleware.js
+++ b/middleware.js
@@ -21,10 +21,6 @@ module.exports = function(compiler, options) {
 	};
 	var shared = Shared(context);
 
-	if(options.mimeTypes) {
-		mime.define(options.mimeTypes);
-	}
-
 	// The middleware function
 	function webpackDevMiddleware(req, res, next) {
 		function goNext() {

--- a/test/Server.test.js
+++ b/test/Server.test.js
@@ -146,6 +146,32 @@ describe("Server", function() {
 		});
 	});
 
+	describe("custom mimeTypes", function() {
+		before(function(done) {
+			app = express();
+			var compiler = webpack(webpackConfig);
+			var instance = middleware(compiler, {
+				stats: "errors-only",
+				quiet: true,
+				index: "Index.phtml",
+				mimeTypes: {
+					"text/html": ["phtml"]
+				}
+			});
+			app.use(instance);
+			listen = listenShorthand(done);
+			instance.fileSystem.writeFileSync("/Index.phtml", "welcome");
+		});
+		after(close);
+
+		it("request to Index.phtml", function(done) {
+			request(app).get("/")
+				.expect("welcome")
+				.expect("Content-Type", /text\/html/)
+				.expect(200, done);
+		});
+	});
+
 	describe("MultiCompiler", function() {
 		before(function(done) {
 			app = express();


### PR DESCRIPTION
Please look here https://github.com/webpack/webpack-dev-middleware/blob/master/middleware.js#L65:

```js
res.setHeader("Content-Type", mime.lookup(filename) + "; charset=UTF-8");
```

The line above detemine the mimeType of file, but I have a special file, Index.phtml, so I have to defining custom mimeType

Example:
```js
app.use(webpackMiddleware(webpack({
    // webpack options
    // webpackMiddleware takes a Compiler object as first parameter
    // which is returned by webpack(...) without callback.
    entry: "...",
    output: {
        path: "/"
        // no real path is required, just pass "/"
        // but it will work with other paths too.
    }
}), {
    // ......

    mimeTypes: {
        'text/html': ['phtml']
    }
}));
```