### PR TITLE
added support for multi-compiler configuration

### DIFF
--- a/lib/GetFilenameFromUrl.js
+++ b/lib/GetFilenameFromUrl.js
@@ -33,4 +33,20 @@ function getFilenameFromUrl(publicPath, outputPath, url) {
 
 }
 
-module.exports = getFilenameFromUrl;
+// support for multi-compiler configuration
+// see: https://github.com/webpack/webpack-dev-server/issues/641
+module.exports = function(publicPath, compiler, url) {
+	var compilers = compiler && compiler.compilers;
+	if(Array.isArray(compilers)) {
+		var compilerPublicPath;
+		for(var i = 0; i < compilers.length; i++) {
+			compilerPublicPath = compilers[i].options
+				&& compilers[i].options.output
+				&& compilers[i].options.output.publicPath;
+			if(url.indexOf(compilerPublicPath) === 0) {
+				return getFilenameFromUrl(compilerPublicPath, compilers[i].outputPath, url);
+			}
+		}
+	}
+	return getFilenameFromUrl(publicPath, compiler.outputPath, url);
+};

--- a/middleware.js
+++ b/middleware.js
@@ -40,9 +40,11 @@ function getFilenameFromUrl(publicPath, compiler, url) {
 	if(Array.isArray(compilers)) {
 		var compilerPublicPath;
 		for(var i = 0; i < compilers.length; i++) {
-			compilerPublicPath = compiler.options && compiler.options.output && compiler.options.output.publicPath;
+			compilerPublicPath = compilers[i].options
+				&& compilers[i].options.output
+				&& compilers[i].options.output.publicPath;
 			if(url.indexOf(compilerPublicPath) === 0) {
-				return _getFilenameFromUrl(compilerPublicPath, compiler.outputPath, url);
+				return _getFilenameFromUrl(compilerPublicPath, compilers[i].outputPath, url);
 			}
 		}
 	}

--- a/middleware.js
+++ b/middleware.js
@@ -6,7 +6,7 @@ var MemoryFileSystem = require("memory-fs");
 var mime = require("mime");
 var parseRange = require("range-parser");
 var pathIsAbsolute = require("path-is-absolute");
-var _getFilenameFromUrl = require("./lib/GetFilenameFromUrl");
+var getFilenameFromUrl = require("./lib/GetFilenameFromUrl");
 var pathJoin = require("./lib/PathJoin");
 
 var HASH_REGEXP = /[0-9a-f]{10,}/;
@@ -32,24 +32,6 @@ var defaultReporter = function(reporterOptions) {
 		options.log("webpack: bundle is now INVALID.");
 	}
 };
-
-// support for multi-compiler configuration
-// see: https://github.com/webpack/webpack-dev-server/issues/641
-function getFilenameFromUrl(publicPath, compiler, url) {
-	var compilers = compiler && compiler.compilers;
-	if(Array.isArray(compilers)) {
-		var compilerPublicPath;
-		for(var i = 0; i < compilers.length; i++) {
-			compilerPublicPath = compilers[i].options
-				&& compilers[i].options.output
-				&& compilers[i].options.output.publicPath;
-			if(url.indexOf(compilerPublicPath) === 0) {
-				return _getFilenameFromUrl(compilerPublicPath, compilers[i].outputPath, url);
-			}
-		}
-	}
-	return _getFilenameFromUrl(publicPath, compiler.outputPath, url);
-}
 
 // constructor for the middleware
 module.exports = function(compiler, options) {

--- a/test/GetFilenameFromUrl.test.js
+++ b/test/GetFilenameFromUrl.test.js
@@ -118,7 +118,7 @@ describe("GetFilenameFromUrl", function() {
 					{ outputPath: "/bar", options: { output: { publicPath: "/css/" } } }
 				],
 				outputPath: "/root",
-				publicPath: "/test",
+				publicPath: "/test/",
 				expected: "/foo/sample.js"
 			}, {
 				url: "/css/sample.css",
@@ -127,7 +127,7 @@ describe("GetFilenameFromUrl", function() {
 					{ outputPath: "/bar", options: { output: { publicPath: "/css/" } } }
 				],
 				outputPath: "/root",
-				publicPath: "/test",
+				publicPath: "/test/",
 				expected: "/bar/sample.css"
 			}, {
 				url: "/other/sample.txt",
@@ -136,7 +136,7 @@ describe("GetFilenameFromUrl", function() {
 					{ outputPath: "/bar", options: { output: { publicPath: "/css/" } } }
 				],
 				outputPath: "/root",
-				publicPath: "/test",
+				publicPath: "/test/",
 				expected: false
 			}, {
 				url: "/test/sample.txt",

--- a/test/GetFilenameFromUrl.test.js
+++ b/test/GetFilenameFromUrl.test.js
@@ -111,6 +111,42 @@ describe("GetFilenameFromUrl", function() {
 				outputPath: "/root",
 				publicPath: "/",
 				expected: "/root/other/sample.txt"
+			}, {
+				url: "/js/sample.js",
+				compilers: [
+					{ outputPath: "/foo", options: { output: { publicPath: "/js/" } } },
+					{ outputPath: "/bar", options: { output: { publicPath: "/css/" } } }
+				],
+				outputPath: "/root",
+				publicPath: "/test",
+				expected: "/foo/sample.js"
+			}, {
+				url: "/css/sample.css",
+				compilers: [
+					{ outputPath: "/foo", options: { output: { publicPath: "/js/" } } },
+					{ outputPath: "/bar", options: { output: { publicPath: "/css/" } } }
+				],
+				outputPath: "/root",
+				publicPath: "/test",
+				expected: "/bar/sample.css"
+			}, {
+				url: "/other/sample.txt",
+				compilers: [
+					{ outputPath: "/foo", options: { output: { publicPath: "/js/" } } },
+					{ outputPath: "/bar", options: { output: { publicPath: "/css/" } } }
+				],
+				outputPath: "/root",
+				publicPath: "/test",
+				expected: false
+			}, {
+				url: "/test/sample.txt",
+				compilers: [
+					{ outputPath: "/foo", options: { output: { publicPath: "/js/" } } },
+					{ outputPath: "/bar", options: { output: { publicPath: "/css/" } } }
+				],
+				outputPath: "/root",
+				publicPath: "/test/",
+				expected: "/root/sample.txt"
 			}
 		];
 		results.forEach(testUrl);

--- a/test/GetFilenameFromUrl.test.js
+++ b/test/GetFilenameFromUrl.test.js
@@ -2,7 +2,7 @@ var should = require("should");
 var getFilenameFromUrl = require("../lib/GetFilenameFromUrl");
 
 function testUrl(options) {
-	var url = getFilenameFromUrl(options.publicPath, options.outputPath, options.url);
+	var url = getFilenameFromUrl(options.publicPath, options, options.url);
 	should.strictEqual(url, options.expected);
 }
 

--- a/test/GetFilenameFromUrl.test.js
+++ b/test/GetFilenameFromUrl.test.js
@@ -28,47 +28,47 @@ describe("GetFilenameFromUrl", function() {
 				url: "/test.html?foo=bar",
 				outputPath: "/",
 				publicPath: "/",
-				expected: "/test.html",
+				expected: "/test.html"
 			}, {
 				url: "/a.js",
 				outputPath: "/dist",
 				publicPath: "/",
-				expected: "/dist/a.js",
+				expected: "/dist/a.js"
 			}, {
 				url: "/b.js",
 				outputPath: "/",
 				publicPath: undefined,
-				expected: "/b.js",
+				expected: "/b.js"
 			}, {
 				url: "/c.js",
 				outputPath: undefined,
 				publicPath: undefined,
-				expected: "/c.js",
+				expected: "/c.js"
 			}, {
 				url: "/more/complex/path.js",
 				outputPath: "/a",
 				publicPath: "/",
-				expected: "/a/more/complex/path.js",
+				expected: "/a/more/complex/path.js"
 			}, {
 				url: "/more/complex/path.js",
 				outputPath: "/a",
 				publicPath: "/complex",
-				expected: false,
+				expected: false
 			}, {
 				url: "c.js",
 				outputPath: "/dist",
 				publicPath: "/",
-				expected: false, // publicPath is not in url, so it should fail
+				expected: false // publicPath is not in url, so it should fail
 			}, {
 				url: "/bar/",
 				outputPath: "/foo",
 				publicPath: "/bar/",
-				expected: "/foo",
+				expected: "/foo"
 			}, {
 				url: "/bar/",
 				outputPath: "/",
 				publicPath: "http://localhost/foo/",
-				expected: false,
+				expected: false
 			}, {
 				url: "http://test.domain/test/sample.js",
 				outputPath: "/",
@@ -84,6 +84,33 @@ describe("GetFilenameFromUrl", function() {
 				outputPath: "/",
 				publicPath: "//test.domain/protocol/relative/",
 				expected: "/sample.js"
+			}, {
+				url: "/js/sample.js",
+				compilers: [
+					{ outputPath: "/foo", options: { output: { publicPath: "/js/" } } },
+					{ outputPath: "/bar", options: { output: { publicPath: "/css/" } } }
+				],
+				outputPath: "/root",
+				publicPath: "/",
+				expected: "/foo/sample.js"
+			}, {
+				url: "/css/sample.css",
+				compilers: [
+					{ outputPath: "/foo", options: { output: { publicPath: "/js/" } } },
+					{ outputPath: "/bar", options: { output: { publicPath: "/css/" } } }
+				],
+				outputPath: "/root",
+				publicPath: "/",
+				expected: "/bar/sample.css"
+			}, {
+				url: "/other/sample.txt",
+				compilers: [
+					{ outputPath: "/foo", options: { output: { publicPath: "/js/" } } },
+					{ outputPath: "/bar", options: { output: { publicPath: "/css/" } } }
+				],
+				outputPath: "/root",
+				publicPath: "/",
+				expected: "/root/other/sample.txt"
 			}
 		];
 		results.forEach(testUrl);

--- a/test/Server.test.js
+++ b/test/Server.test.js
@@ -153,7 +153,7 @@ describe("Server", function() {
 			var instance = middleware(compiler, {
 				stats: "errors-only",
 				quiet: true,
-				publicPath: "/",
+				publicPath: "/"
 			});
 			app.use(instance);
 			listen = listenShorthand(done);
@@ -161,9 +161,9 @@ describe("Server", function() {
 		after(close);
 
 		it("request to both bundle files", function(done) {
-			request(app).get("/foo.js")
+			request(app).get("/js1/foo.js")
 			.expect(200, function() {
-				request(app).get("/bar.js")
+				request(app).get("/js2/bar.js")
 				.expect(200, done);
 			});
 		});

--- a/test/fixtures/server-test/webpack.array.config.js
+++ b/test/fixtures/server-test/webpack.array.config.js
@@ -3,13 +3,15 @@ module.exports = [{
 	entry: "./foo.js",
 	output: {
 		filename: "foo.js",
-		path: "/"
+		path: "/js1",
+		publicPath: "/js1/"
 	}
 }, {
 	context: __dirname,
 	entry: "./bar.js",
 	output: {
 		filename: "bar.js",
-		path: "/"
+		path: "/js2",
+		publicPath: "/js2/"
 	}
 }];


### PR DESCRIPTION
see: https://github.com/webpack/webpack-dev-server/issues/641

The problem occurs because the `outputPath` of a multi-compiler configuration is the common path of all compilers. The fix check if we are running multi-compiler and tries to match each compiler `publicPath` to the given URL. If we find a match we use the `publicPath` and `outputPath` of that compiler, otherwise we fallback the combined definitions, done by webpack's MultiCompiler mode.

Fixes webpack/webpack/issues/1849, fixes webpack/webpack-dev-server/issues/641