### PR TITLE
Stop serving index.html if options.index is falsy

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ app.use(webpackMiddleware(webpack({
 	publicPath: "/assets/",
 	// public path to bind the middleware to
 	// use the same as in webpack
-	
+
 	index: "index.html",
-	// the index path for web server
+	// The index path for web server.
+	// If falsy, the server will not respond to requests to the root URL.
 
 	headers: { "X-Custom-Header": "yes" },
 	// custom headers

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ app.use(webpackMiddleware(webpack({
 	// use the same as in webpack
 
 	index: "index.html",
-	// The index path for web server.
-	// If falsy, the server will not respond to requests to the root URL.
+	// The index path for web server, defaults to "index.html".
+	// If falsy (but not undefined), the server will not respond to requests to the root URL.
 
 	headers: { "X-Custom-Header": "yes" },
 	// custom headers

--- a/middleware.js
+++ b/middleware.js
@@ -47,7 +47,15 @@ module.exports = function(compiler, options) {
 					var stat = context.fs.statSync(filename);
 					if(!stat.isFile()) {
 						if(stat.isDirectory()) {
-							filename = pathJoin(filename, context.options.index || "index.html");
+							var index = context.options.index;
+
+							if(index === undefined || index === true) {
+								index = "index.html";
+							} else if(!index) {
+								throw "next";
+							}
+
+							filename = pathJoin(filename, index);
 							stat = context.fs.statSync(filename);
 							if(!stat.isFile()) throw "next";
 						} else {

--- a/test/Server.test.js
+++ b/test/Server.test.js
@@ -101,6 +101,27 @@ describe("Server", function() {
 		});
 	});
 
+	describe("no index mode", function() {
+		before(function(done) {
+			app = express();
+			var compiler = webpack(webpackConfig);
+			app.use(middleware(compiler, {
+				stats: "errors-only",
+				quiet: true,
+				index: false,
+				publicPath: "/",
+			}));
+			listen = listenShorthand(done);
+		});
+		after(close);
+
+		it("request to directory", function(done) {
+			request(app).get("/")
+				.expect("Content-Type", "text/html; charset=utf-8")
+				.expect(404, done);
+		});
+	});
+
 	describe("lazy mode", function() {
 		before(function(done) {
 			app = express();


### PR DESCRIPTION
Resolves https://github.com/webpack/webpack-dev-middleware/issues/153, see the discussion there.

New logic for requests that resolve to a directory:

1. If `options.index` is `true` or `undefined`, attempt to serve `index.html`
2. If `options.index` is falsy, do not serve anything
3. Otherwise, serve `options.index`