### PR TITLE
Fix error handling in compiler `watch()` and `run()`

### DIFF
--- a/lib/Shared.js
+++ b/lib/Shared.js
@@ -11,6 +11,7 @@ module.exports = function Shared(context) {
 			if(typeof options.reporter !== "function") options.reporter = share.defaultReporter;
 			if(typeof options.log !== "function") options.log = console.log.bind(console);
 			if(typeof options.warn !== "function") options.warn = console.warn.bind(console);
+			if(typeof options.error !== "function") options.error = console.error.bind(console);
 			if(typeof options.watchDelay !== "undefined") {
 				// TODO remove this in next major version
 				options.warn("options.watchDelay is deprecated: Use 'options.watchOptions.aggregateTimeout' instead");
@@ -149,9 +150,7 @@ module.exports = function Shared(context) {
 			var compiler = context.compiler;
 			// start watching
 			if(!options.lazy) {
-				var watching = compiler.watch(options.watchOptions, function(err) {
-					if(err) throw err;
-				});
+				var watching = compiler.watch(options.watchOptions, share.handleCompilerCallback);
 				context.watching = watching;
 			} else {
 				context.state = true;
@@ -160,11 +159,15 @@ module.exports = function Shared(context) {
 		rebuild: function rebuild() {
 			if(context.state) {
 				context.state = false;
-				context.compiler.run(function(err) {
-					if(err) throw err;
-				});
+				context.compiler.run(share.handleCompilerCallback);
 			} else {
 				context.forceRebuild = true;
+			}
+		},
+		handleCompilerCallback: function(err) {
+			if(err) {
+				context.options.error(err.stack || err);
+				if(err.details) context.options.error(err.details);
 			}
 		},
 		handleRequest: function(filename, processRequest, req) {

--- a/test/CompilerCallbacks.test.js
+++ b/test/CompilerCallbacks.test.js
@@ -1,0 +1,40 @@
+var should = require("should");
+var middleware = require("../middleware");
+require("mocha-sinon");
+
+describe("CompilerCallbacks", function() {
+	var plugins = {};
+	var compiler = {
+		watch: function() {},
+		plugin: function(name, callback) {
+			plugins[name] = callback;
+		}
+	};
+	beforeEach(function() {
+		plugins = {};
+	});
+
+	it("watch error should be reported to console", function(done) {
+		var error = new Error("Oh noes!");
+		this.sinon.stub(compiler, "watch", function(opts, callback) {
+			callback(error);
+		});
+		this.sinon.stub(console, "error");
+		middleware(compiler);
+		should.strictEqual(console.error.callCount, 1);
+		should.strictEqual(console.error.calledWith(error.stack), true);
+		done();
+	});
+
+	it("options.error should be used on watch error", function(done) {
+		this.sinon.stub(compiler, "watch", function(opts, callback) {
+			callback(new Error("Oh noes!"));
+		});
+		middleware(compiler, {
+			error: function(err) {
+				err.should.startWith("Error: Oh noes!");
+				done();
+			}
+		});
+	});
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

Yes.

**Summary**

See #156. When the compiler wanted to report an error in the bundle (e.g. because of a plugin), it would throw the error and quit the process.

I've changed this to work more like the [webpack watch mode](https://github.com/webpack/webpack/blob/287eb18076d80688be03a55431918b628b25f436/bin/webpack.js#L302-L303); it shows the error with `console.error` but it keeps running (because the error can be fixed with a new compilation).

Optionally, it's possible to hide / customize this error by using `options.error`.

**Does this PR introduce a breaking change?**

Not really; previously the process would quit and now it doesn't.

**Other information**

Fixes #156