### PR TITLE
Allow webpack 2 RC

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
   "peerDependencies": {
-    "webpack": "1 || ^2.1.0-beta"
+    "webpack": "1 || ^2.1.0-beta || ^2.2.0-rc.0"
   },
   "dependencies": {
     "memory-fs": "~0.4.1",


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Expand the peer dependency option to include webpack 2 rc


**Did you add tests for your changes?**
No

**Summary**
Peer dependency errors are thrown by package managers, as the current version does not allow webpack 2 rc

**Does this PR introduce a breaking change?**
No

