### PR TITLE
Improve messages when bundle is compiling and done with compiling

### DIFF
--- a/lib/Shared.js
+++ b/lib/Shared.js
@@ -44,7 +44,13 @@ module.exports = function Shared(context) {
 					options.log(stats.toString(options.stats));
 				}
 				if(!options.noInfo && !options.quiet) {
-					options.log("webpack: " + (stats.hasErrors() ? "Failed to compile." : "Compiled successfully."));
+					var msg = "Compiled successfully.";
+					if(stats.hasErrors()) {
+						msg = "Failed to compile.";
+					} else if(stats.hasWarnings()) {
+						msg = "Compiled with warnings.";
+					}
+					options.log("webpack: " + msg);
 				}
 			} else {
 				options.log("webpack: Compiling...");

--- a/lib/Shared.js
+++ b/lib/Shared.js
@@ -44,10 +44,10 @@ module.exports = function Shared(context) {
 					options.log(stats.toString(options.stats));
 				}
 				if(!options.noInfo && !options.quiet) {
-					options.log("webpack: bundle is now VALID.");
+					options.log("webpack: " + (stats.hasErrors() ? "Failed to compile." : "Compiled successfully."));
 				}
 			} else {
-				options.log("webpack: bundle is now INVALID.");
+				options.log("webpack: Compiling...");
 			}
 		},
 		handleRangeHeaders: function handleRangeHeaders(content, req, res) {

--- a/test/Reporter.test.js
+++ b/test/Reporter.test.js
@@ -15,6 +15,15 @@ var simpleStats = {
 	}
 };
 
+var errorStats = {
+	hasErrors: function() {
+		return true;
+	},
+	hasWarnings: function() {
+		return false;
+	}
+};
+
 describe("Reporter", function() {
 	var plugins = {};
 	var compiler = {
@@ -33,13 +42,24 @@ describe("Reporter", function() {
 	});
 
 	describe("valid/invalid messages", function() {
-		it("should show valid message", function(done) {
+		it("should show compiled successfully message", function(done) {
 			middleware(compiler);
 
 			plugins.done(simpleStats);
 			setTimeout(function() {
 				should.strictEqual(console.log.callCount, 2);
-				should.strictEqual(console.log.calledWith("webpack: bundle is now VALID."), true);
+				should.strictEqual(console.log.calledWith("webpack: Compiled successfully."), true);
+				done();
+			});
+		});
+
+		it("should show compiled successfully message", function(done) {
+			middleware(compiler);
+
+			plugins.done(errorStats);
+			setTimeout(function() {
+				should.strictEqual(console.log.callCount, 2);
+				should.strictEqual(console.log.calledWith("webpack: Failed to compile."), true);
 				done();
 			});
 		});
@@ -70,7 +90,7 @@ describe("Reporter", function() {
 			plugins.invalid();
 			setTimeout(function() {
 				should.strictEqual(console.log.callCount, 1);
-				should.strictEqual(console.log.calledWith("webpack: bundle is now INVALID."), true);
+				should.strictEqual(console.log.calledWith("webpack: Compiling..."), true);
 				done();
 			});
 		});

--- a/test/Reporter.test.js
+++ b/test/Reporter.test.js
@@ -24,6 +24,15 @@ var errorStats = {
 	}
 };
 
+var warningStats = {
+	hasErrors: function() {
+		return false;
+	},
+	hasWarnings: function() {
+		return true;
+	}
+};
+
 describe("Reporter", function() {
 	var plugins = {};
 	var compiler = {
@@ -58,8 +67,17 @@ describe("Reporter", function() {
 
 			plugins.done(errorStats);
 			setTimeout(function() {
-				should.strictEqual(console.log.callCount, 2);
 				should.strictEqual(console.log.calledWith("webpack: Failed to compile."), true);
+				done();
+			});
+		});
+
+		it("should show compiled with warnings message", function(done) {
+			middleware(compiler);
+
+			plugins.done(warningStats);
+			setTimeout(function() {
+				should.strictEqual(console.log.calledWith("webpack: Compiled with warnings."), true);
 				done();
 			});
 		});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Change, a small improvement in DX.

**Did you add tests for your changes?**

Yes

**Summary**

When the bundle is compiling, the console showed this:

```
webpack: bundle is now INVALID.
```

When it is done compiling, regardless of errors, it showed this:

```
webpack: bundle is now VALID.
```

This is very confusing, because most people think when it is "valid", that the bundle has successfully compiled. Also, when it says "bundle is now INVALID", people can think they have done something wrong.

<hr>

This PR indents to clarify these messages;

When the bundle is compiling:

```
webpack: Compiling...
```

When the bundle is done compiling, but has errors:

```
webpack: Failed to compile.
```

When the bundle is done compiling, no errors:

```
webpack: Compiled successfully.
```

Note that if there are warnings, it will say "Compiled successfully." This is because a bundle with warnings will still work. I could add a special case for this, maybe "Compiled successfully, but with warnings." ?

**Does this PR introduce a breaking change?**

Not really, but I _think_ there might be people who have hacked something based on these messages.

**Other information**

Inspired by [this discussion on Twitter](https://twitter.com/dan_abramov/status/812058255753183232). The messages are also stolen from create-react-app.

cc @gaearon