### PR TITLE
Fix parsing urls with spaces. Use decodeURIComponent for getFilenameFromUrl final output

### DIFF
--- a/lib/GetFilenameFromUrl.js
+++ b/lib/GetFilenameFromUrl.js
@@ -3,7 +3,6 @@ var urlParse = require("url").parse;
 
 function getFilenameFromUrl(publicPath, outputPath, url) {
 	var filename;
-	url = decodeURIComponent(url);
 
 	// localPrefix is the folder our bundle should be in
 	var localPrefix = urlParse(publicPath || "/", false, true);
@@ -30,7 +29,7 @@ function getFilenameFromUrl(publicPath, outputPath, url) {
 		return false;
 	}
 	// and if not match, use outputPath as filename
-	return filename ? pathJoin(outputPath, filename) : outputPath;
+	return decodeURIComponent(filename ? pathJoin(outputPath, filename) : outputPath);
 
 }
 

--- a/test/GetFilenameFromUrl.test.js
+++ b/test/GetFilenameFromUrl.test.js
@@ -89,7 +89,12 @@ describe("GetFilenameFromUrl", function() {
 				outputPath: "/",
 				publicPath: "//test.domain/protocol/relative/",
 				expected: "/sample.js"
-			}
+			}, {
+				url: "/pathname%20with%20spaces.js",
+				outputPath: "/",
+				publicPath: "/",
+				expected: "/pathname with spaces.js"
+			},
 		];
 		results.forEach(testUrl);
 	});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix.

**Did you add tests for your changes?**

Yes.

**Summary**

This PR fix getFilenameFromUrl output result. 
getFilenameFromUrl function does not properly parse url with spaces.
It is happens because url.parse return encoded pathname.
Look screenshot please:

![image](https://cloud.githubusercontent.com/assets/5237085/23354929/6e439b48-fce4-11e6-9785-72131c3ba4d4.png)

So getFilenameFromUrl can't return right filename that contains spaces.
My approach is decode final output again.

**Does this PR introduce a breaking change?**

It's shouldn't.
