### PR TITLE
Avoid setting http status code explicitly

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -69,8 +69,7 @@ module.exports = function(compiler, options) {
 					res.setHeader(name, context.options.headers[name]);
 				}
 			}
-			// Express automatically sets the statusCode to 200, but not all servers do (Koa).
-			res.statusCode = res.statusCode || 200;
+
 			if(res.send) res.send(content);
 			else res.end(content);
 		}


### PR DESCRIPTION
Related to webpack/webpack-dev-middleware#174