### PR TITLE
Fix webpackDevMiddleware to work with Koa2, a Promise must always be returned

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -39,41 +39,43 @@ module.exports = function(compiler, options) {
 		var filename = getFilenameFromUrl(context.options.publicPath, context.compiler.outputPath, req.url);
 		if(filename === false) return goNext();
 
+		return new Promise(function(resolve) {
+			shared.handleRequest(filename, processRequest, req);
+			function processRequest() {
+				try {
+					var stat = context.fs.statSync(filename);
+					if(!stat.isFile()) {
+						if(stat.isDirectory()) {
+							filename = pathJoin(filename, context.options.index || "index.html");
+							stat = context.fs.statSync(filename);
+							if(!stat.isFile()) throw "next";
+						} else {
+							throw "next";
+						}
+					}
+				} catch(e) {
+					return resolve(goNext());
+				}
 
-		shared.handleRequest(filename, processRequest, req);
-
-		function processRequest() {
-			try {
-				var stat = context.fs.statSync(filename);
-				if(!stat.isFile()) {
-					if(stat.isDirectory()) {
-						filename = pathJoin(filename, context.options.index || "index.html");
-						stat = context.fs.statSync(filename);
-						if(!stat.isFile()) throw "next";
-					} else {
-						throw "next";
+				// server content
+				var content = context.fs.readFileSync(filename);
+				content = shared.handleRangeHeaders(content, req, res);
+				res.setHeader("Access-Control-Allow-Origin", "*"); // To support XHR, etc.
+				res.setHeader("Content-Type", mime.lookup(filename) + "; charset=UTF-8");
+				res.setHeader("Content-Length", content.length);
+				if(context.options.headers) {
+					for(var name in context.options.headers) {
+						res.setHeader(name, context.options.headers[name]);
 					}
 				}
-			} catch(e) {
-				return goNext();
+				// Express automatically sets the statusCode to 200, but not all servers do (Koa).
+				res.statusCode = res.statusCode || 200;
+				if(res.send) res.send(content);
+				else res.end(content);
+				resolve();
 			}
+		});
 
-			// server content
-			var content = context.fs.readFileSync(filename);
-			content = shared.handleRangeHeaders(content, req, res);
-			res.setHeader("Access-Control-Allow-Origin", "*"); // To support XHR, etc.
-			res.setHeader("Content-Type", mime.lookup(filename) + "; charset=UTF-8");
-			res.setHeader("Content-Length", content.length);
-			if(context.options.headers) {
-				for(var name in context.options.headers) {
-					res.setHeader(name, context.options.headers[name]);
-				}
-			}
-			// Express automatically sets the statusCode to 200, but not all servers do (Koa).
-			res.statusCode = res.statusCode || 200;
-			if(res.send) res.send(content);
-			else res.end(content);
-		}
 	}
 
 	webpackDevMiddleware.getFilenameFromUrl = getFilenameFromUrl.bind(this, context.options.publicPath, context.compiler.outputPath);


### PR DESCRIPTION
ping @shellscape

**What kind of change does this PR introduce?**

It's a bugfix to support koa2 correctly, next() is called but not returned, need to be wrapped into a Promise.

**Did you add tests for your changes?**

No

**Summary**

The issue is the following while integrated in koa-webpack for koa2:

the `next()` function is called asynchronously in one case but not return, in this case `undefined` is returned causing koa to move up into the stack of middleware and send the response, meanwhile the `next()` function is called causing the next middleware to be called and sending a response of its own throwing the error "Can't set headers after they are sent". I'm not sure if this kind of patch will be accepted. Wrapping the code where next is called into a Promise does the job to chain things correctly.

**Does this PR introduce a breaking change?**

The function returns now a Promise, or the `next()` returned value which can be a Promise (in koa2) or something else if next is coming from express. I don't think the returned type matter except for koa2 integration.
