### PR TITLE
Add a fallback argument to handle unreachable file

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -22,7 +22,7 @@ module.exports = function(compiler, options) {
 	var shared = Shared(context);
 
 
-  // The middleware function
+        // The middleware function
 	function webpackDevMiddleware(req, res, next) {
 		function goNext() {
 			if(!context.options.serverSideRender) return next();
@@ -61,7 +61,7 @@ module.exports = function(compiler, options) {
 				return goNext();
 			}
 
-      // server content
+                        // server content
 			var content = context.fs.readFileSync(filename);
 			content = shared.handleRangeHeaders(content, req, res);
 			res.setHeader("Access-Control-Allow-Origin", "*"); // To support XHR, etc.
@@ -72,7 +72,7 @@ module.exports = function(compiler, options) {
 					res.setHeader(name, context.options.headers[name]);
 				}
 			}
-      // Express automatically sets the statusCode to 200, but not all servers do (Koa).
+                        // Express automatically sets the statusCode to 200, but not all servers do (Koa).
 			res.statusCode = res.statusCode || 200;
 			if(res.send) res.send(content);
 			else res.end(content);

--- a/middleware.js
+++ b/middleware.js
@@ -1,7 +1,7 @@
 /*
-   MIT License http://www.opensource.org/licenses/mit-license.php
-   Author Tobias Koppers @sokra
-   */
+ MIT License http://www.opensource.org/licenses/mit-license.php
+ Author Tobias Koppers @sokra
+ */
 var mime = require("mime");
 var getFilenameFromUrl = require("./lib/GetFilenameFromUrl");
 var Shared = require("./lib/Shared");
@@ -22,7 +22,7 @@ module.exports = function(compiler, options) {
 	var shared = Shared(context);
 
 
-        // The middleware function
+	// The middleware function
 	function webpackDevMiddleware(req, res, next) {
 		function goNext() {
 			if(!context.options.serverSideRender) return next();
@@ -61,7 +61,7 @@ module.exports = function(compiler, options) {
 				return goNext();
 			}
 
-                        // server content
+			// server content
 			var content = context.fs.readFileSync(filename);
 			content = shared.handleRangeHeaders(content, req, res);
 			res.setHeader("Access-Control-Allow-Origin", "*"); // To support XHR, etc.

--- a/middleware.js
+++ b/middleware.js
@@ -1,7 +1,7 @@
 /*
- MIT License http://www.opensource.org/licenses/mit-license.php
- Author Tobias Koppers @sokra
- */
+   MIT License http://www.opensource.org/licenses/mit-license.php
+   Author Tobias Koppers @sokra
+   */
 var mime = require("mime");
 var getFilenameFromUrl = require("./lib/GetFilenameFromUrl");
 var Shared = require("./lib/Shared");
@@ -22,7 +22,7 @@ module.exports = function(compiler, options) {
 	var shared = Shared(context);
 
 
-	// The middleware function
+  // The middleware function
 	function webpackDevMiddleware(req, res, next) {
 		function goNext() {
 			if(!context.options.serverSideRender) return next();
@@ -40,6 +40,9 @@ module.exports = function(compiler, options) {
 		if(filename === false) return goNext();
 
 
+		if(!context.fs.existsSync(filename) && context.options.fallBack) {
+			filename = getFilenameFromUrl(context.options.publicPath, context.compiler.outputPath,context.options.publicPath);
+		}
 		shared.handleRequest(filename, processRequest, req);
 
 		function processRequest() {
@@ -58,7 +61,7 @@ module.exports = function(compiler, options) {
 				return goNext();
 			}
 
-			// server content
+      // server content
 			var content = context.fs.readFileSync(filename);
 			content = shared.handleRangeHeaders(content, req, res);
 			res.setHeader("Access-Control-Allow-Origin", "*"); // To support XHR, etc.
@@ -69,7 +72,8 @@ module.exports = function(compiler, options) {
 					res.setHeader(name, context.options.headers[name]);
 				}
 			}
-
+      // Express automatically sets the statusCode to 200, but not all servers do (Koa).
+			res.statusCode = res.statusCode || 200;
 			if(res.send) res.send(content);
 			else res.end(content);
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-dev-middleware",
-  "version": "1.10.2",
+  "version": "1.10.1",
   "author": "Tobias Koppers @sokra",
   "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-dev-middleware",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "author": "Tobias Koppers @sokra",
   "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
   "peerDependencies": {

--- a/test/API.test.js
+++ b/test/API.test.js
@@ -1,6 +1,7 @@
+require("mocha-sinon");
+
 var middleware = require("../middleware");
 var should = require("should");
-require("mocha-sinon");
 
 var options = {
 	quiet: true,

--- a/test/API.test.js
+++ b/test/API.test.js
@@ -1,5 +1,6 @@
 var middleware = require("../middleware");
 var should = require("should");
+require("mocha-sinon");
 
 var options = {
 	quiet: true,
@@ -150,6 +151,40 @@ describe("Advanced API", function() {
 			var filename = instance.getFilenameFromUrl("/public/index.html");
 			should.strictEqual(filename, "/output/index.html");
 			done();
+		});
+	});
+	describe("Handle the case when url is not reachable", function() {
+		var next;
+		beforeEach(function() {
+			next = this.sinon.stub();
+		});
+
+		it("Should jump out when fallBack is not set", function(done) {
+			var instance = middleware(compiler, options);
+			var req = { method: "GET", url: "/unreachable.html" };
+			var res = {};
+			should.strictEqual(next.callCount, 0);
+			instance(req,res,next);
+			setTimeout(function() {
+				should.strictEqual(next.callCount, 1);
+				done();
+			});
+		});
+		it("Should serve the / when fallBack is set", function(done) {
+			var options = {
+				quiet: true,
+				publicPath: "/public/",
+				fallBack: true
+			};
+			var instance = middleware(compiler, options);
+			var req = { method: "GET", url: "/public/" };
+			var res = {};
+			should.strictEqual(next.callCount, 0);
+			instance(req,res,next);
+			setTimeout(function() {
+				should.strictEqual(next.callCount, 0);
+				done();
+			});
 		});
 	});
 });


### PR DESCRIPTION

#180
Imagine, we are debugging a react app with react-router. We click
a link sending us to another url. That's ok since all the routing
stuff are handled in the front end. Then we make some modification
to the html and want to refresh the whole page. Now problem arises,
the url is now unreachable in the back end because we have changed
it so that the server has no idea what file to serve.

In this case, we would like the dev server to serve one similar
html no matter what the url is( the root html). That would be the behavior
when fallBack argument is set to true after this commit is merged.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
I added a new feature.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes

<!-- Note that we won't merge your changes if you don't add tests. -->


**Does this PR introduce a breaking change?**
No. The default behavior is untouched if the fallBack argument is
not set to true.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
