### PR TITLE
Use options.log, warn and error for compilation messages

### DIFF
--- a/lib/Shared.js
+++ b/lib/Shared.js
@@ -41,16 +41,22 @@ module.exports = function Shared(context) {
 					options.noInfo)
 					displayStats = false;
 				if(displayStats) {
-					options.log(stats.toString(options.stats));
+					if(stats.hasErrors()) {
+						options.error(stats.toString(options.stats));
+					} else if(stats.hasWarnings()) {
+						options.warn(stats.toString(options.stats));
+					} else {
+						options.log(stats.toString(options.stats));
+					}
 				}
 				if(!options.noInfo && !options.quiet) {
-					var msg = "Compiled successfully.";
 					if(stats.hasErrors()) {
-						msg = "Failed to compile.";
+						options.error("webpack: Failed to compile.");
 					} else if(stats.hasWarnings()) {
-						msg = "Compiled with warnings.";
+						options.warn("webpack: Compiled with warnings.");
+					} else {
+						options.log("webpack: Compiled successfully.");
 					}
-					options.log("webpack: " + msg);
 				}
 			} else {
 				options.log("webpack: Compiling...");

--- a/test/Reporter.test.js
+++ b/test/Reporter.test.js
@@ -48,36 +48,46 @@ describe("Reporter", function() {
 	beforeEach(function() {
 		plugins = {};
 		this.sinon.stub(console, "log");
+		this.sinon.stub(console, "warn");
+		this.sinon.stub(console, "error");
 	});
 
-	describe("valid/invalid messages", function() {
-		it("should show compiled successfully message", function(done) {
+	describe("compilation messages", function() {
+		it("should show 'compiled successfully' message", function(done) {
 			middleware(compiler);
 
 			plugins.done(simpleStats);
 			setTimeout(function() {
 				should.strictEqual(console.log.callCount, 2);
+				should.strictEqual(console.warn.callCount, 0);
+				should.strictEqual(console.error.callCount, 0);
 				should.strictEqual(console.log.calledWith("webpack: Compiled successfully."), true);
 				done();
 			});
 		});
 
-		it("should show compiled successfully message", function(done) {
+		it("should show 'Failed to compile' message in console.error", function(done) {
 			middleware(compiler);
 
 			plugins.done(errorStats);
 			setTimeout(function() {
-				should.strictEqual(console.log.calledWith("webpack: Failed to compile."), true);
+				should.strictEqual(console.log.callCount, 0);
+				should.strictEqual(console.warn.callCount, 0);
+				should.strictEqual(console.error.callCount, 2);
+				should.strictEqual(console.error.calledWith("webpack: Failed to compile."), true);
 				done();
 			});
 		});
 
-		it("should show compiled with warnings message", function(done) {
+		it("should show 'Compiled with warnings' message in console.warn", function(done) {
 			middleware(compiler);
 
 			plugins.done(warningStats);
 			setTimeout(function() {
-				should.strictEqual(console.log.calledWith("webpack: Compiled with warnings."), true);
+				should.strictEqual(console.log.callCount, 0);
+				should.strictEqual(console.warn.callCount, 2);
+				should.strictEqual(console.error.callCount, 0);
+				should.strictEqual(console.warn.calledWith("webpack: Compiled with warnings."), true);
 				done();
 			});
 		});


### PR DESCRIPTION
When the compilation fails or has warnings, the compilation
messages are outputted in console.log not using the options.error
and options.warn functions.

This commit change the defaultReporter to output the stats
and final message to the options.error when the compilation
has errors or the options.warn when it has warnings.

The Reporter.test.js test cases are updated accordingly.