### PR TITLE
set Access-Control-Allow-Origin to * to support XHR

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -61,6 +61,7 @@ module.exports = function(compiler, options) {
 			// server content
 			var content = context.fs.readFileSync(filename);
 			content = shared.handleRangeHeaders(content, req, res);
+			res.setHeader("Access-Control-Allow-Origin", "*"); // To support XHR, etc.
 			res.setHeader("Content-Type", mime.lookup(filename) + "; charset=UTF-8");
 			res.setHeader("Content-Length", content.length);
 			if(context.options.headers) {


### PR DESCRIPTION
*I started my back-end server on localhost:5000 and front-end server on 8088.*
*When I used this middleware for HMR, I ocurred with a problem below:*

![](https://raw.githubusercontent.com/elevenBeans/Grocery/master/OMG.png)

Considering that it's quite common to use 2 different servers when developing a webapp, CORS should be supported right?

*I added `Access-Control-Allow-Origin` header and set it to \**

Thanks.
BR
