### PR TITLE
Parse pathname from req rather than use req.url, fix #155.

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -3,11 +3,10 @@
  Author Tobias Koppers @sokra
  */
 var mime = require("mime");
+var parseUrl = require("parseurl");
 var getFilenameFromUrl = require("./lib/GetFilenameFromUrl");
 var Shared = require("./lib/Shared");
 var pathJoin = require("./lib/PathJoin");
-
-var parseUrl = require('parseurl');
 
 // constructor for the middleware
 module.exports = function(compiler, options) {

--- a/middleware.js
+++ b/middleware.js
@@ -7,6 +7,8 @@ var getFilenameFromUrl = require("./lib/GetFilenameFromUrl");
 var Shared = require("./lib/Shared");
 var pathJoin = require("./lib/PathJoin");
 
+var parseUrl = require('parseurl');
+
 // constructor for the middleware
 module.exports = function(compiler, options) {
 
@@ -36,7 +38,7 @@ module.exports = function(compiler, options) {
 			return goNext();
 		}
 
-		var filename = getFilenameFromUrl(context.options.publicPath, context.compiler, req.url);
+		var filename = getFilenameFromUrl(context.options.publicPath, context.compiler, parseUrl.original(req).pathname);
 		if(filename === false) return goNext();
 
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "memory-fs": "~0.4.1",
     "mime": "^1.3.4",
+    "parseurl": "^1.3.1",
     "path-is-absolute": "^1.0.0",
     "range-parser": "^1.0.3"
   },


### PR DESCRIPTION
**What kind of change does this PR introduce?**

A bugfix, address #155.

**Did you add tests for your changes?**

No need for more tests for my changes.

**Summary**

In this pull request, I replace `req.url` with `parseUrl.original(req).pathname` to get correct path name of directories in HTTP request, so that we could response with the correct default files.

For example, we have the following directory structure

~~~
-- index.html
-- app
 | -- index.html
~~~

and the `options.index` is `index.html`.  When we request `/` we would get `/index.html`. However when we request `/app`, `req.url` would be `/` rather than `/app` and we would get `/index.html` rather than `/app/index.html`.

The pull request fix the issue described above.

**Does this PR introduce a breaking change?**

This PR won't introduce a breaking change.

**Other information**