### PR TITLE
Make serverSideRendering example work consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,21 +137,27 @@ In the server-side rendering mode, __webpack-dev-middleware__ would sets the `st
 Notice that requests for bundle files would still be responded by __webpack-dev-middleware__ and all requests will be pending until the building process is finished in the server-side rendering mode.
 
 ```javascript
+// This function makes server rendering of asset references consistent with different webpack chunk/entry confiugrations
+function normalizeAssets(assets) {
+  return Array.isArray(assets) ? assets : [assets]
+}
+
 app.use(webpackMiddleware(compiler, { serverSideRender: true })
 
 // The following middleware would not be invoked until the latest build is finished.
 app.use((req, res) => {
+  
   const assetsByChunkName = res.locals.webpackStats.toJson().assetsByChunkName
-
+  
   // then use `assetsByChunkName` for server-sider rendering
-	// For example, if you have only one main chunk:
+  // For example, if you have only one main chunk:
 
 	res.send(`
 <html>
   <head>
     <title>My App</title>
 		${
-			assetsByChunkName.main
+			normalizeAssets(assetsByChunkName.main)
 			.filter(path => path.endsWith('.css'))
 			.map(path => `<link rel="stylesheet" href="${path}" />`)
 		}
@@ -159,7 +165,7 @@ app.use((req, res) => {
   <body>
     <div id="root"></div>
 		${
-			assetsByChunkName.main
+			normalizeAssets(assetsByChunkName.main)
 			.filter(path => path.endsWith('.js'))
 			.map(path => `<script src="${path}" />`)
 		}

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ app.use((req, res) => {
 			normalizeAssets(assetsByChunkName.main)
 			.filter(path => path.endsWith('.css'))
 			.map(path => `<link rel="stylesheet" href="${path}" />`)
+			.join('\n')
 		}
   </head>
   <body>
@@ -168,6 +169,7 @@ app.use((req, res) => {
 			normalizeAssets(assetsByChunkName.main)
 			.filter(path => path.endsWith('.js'))
 			.map(path => `<script src="${path}" />`)
+			.join('\n')
 		}
   </body>
 </html>		

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ app.use((req, res) => {
 		${
 			normalizeAssets(assetsByChunkName.main)
 			.filter(path => path.endsWith('.js'))
-			.map(path => `<script src="${path}" />`)
+			.map(path => `<script src="${path}"></script>`)
 			.join('\n')
 		}
   </body>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Documentation

**Did you add tests for your changes?**

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

I was following the examples and realized that it only works if you have more than one `main` bundle (such as js and on css bundle). Adding this one-liner makes it work with or without the extra `main` bundle. This small change also works when adding other named bundles (which would more than likely be single files - **non array**), and supports turning on source maps (which would make the named assets value into arrays).

Additionally, the interpolated values were returning arrays and were not being properly formatted. Therefore, I added a `.join('\n')` call at the end.

**Does this PR introduce a breaking change?**

No
