### PR TITLE
Use querystring.unescape to fallback to safer equivalent that does not throw on malformed URIs

### DIFF
--- a/lib/GetFilenameFromUrl.js
+++ b/lib/GetFilenameFromUrl.js
@@ -1,4 +1,5 @@
 var pathJoin = require("./PathJoin");
+var querystring = require("querystring");
 var urlParse = require("url").parse;
 
 function getFilenameFromUrl(publicPath, outputPath, url) {
@@ -29,8 +30,7 @@ function getFilenameFromUrl(publicPath, outputPath, url) {
 		return false;
 	}
 	// and if not match, use outputPath as filename
-	return decodeURIComponent(filename ? pathJoin(outputPath, filename) : outputPath);
-
+	return querystring.unescape(filename ? pathJoin(outputPath, filename) : outputPath);
 }
 
 // support for multi-compiler configuration

--- a/test/GetFilenameFromUrl.test.js
+++ b/test/GetFilenameFromUrl.test.js
@@ -20,6 +20,11 @@ describe("GetFilenameFromUrl", function() {
 				publicPath: "/",
 				expected: "/föö.js"
 			}, {
+				url: "/%foo%/%foo%.js", // Filenames can contain characters not allowed in URIs
+				outputPath: "/",
+				publicPath: "/",
+				expected: "/%foo%/%foo%.js"
+			}, {
 				url: "/0.19dc5d417382d73dd190.hot-update.js",
 				outputPath: "/",
 				publicPath: "http://localhost:8080/",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR fixes cases like https://github.com/facebookincubator/create-react-app/issues/2439 where the filepath contains characters normally considered malformed in URIs such as '%'.

As stated in the [docs](https://nodejs.org/api/querystring.html):

> By default, the querystring.unescape() method will attempt to use the JavaScript built-in decodeURIComponent() method to decode. If that fails, a safer equivalent that does not throw on malformed URLs will be used.

**Did you add tests for your changes?**

This PR adds a test that confirms that `%` now works on filenames and paths. However, the fix can still give false positives for things like '%bar%' where `%ba` ends up being escaped as percent encoded characters, but I think those are edge cases that might be more pain to fix than it's worth.

I also tested the changes with `create-react-app` by first creating a project in `%__test/test`, confirming that `npm start` fails, then `npm link`ed the changeset and confirmed that the fix allowed the application to launch without throwing.

**Summary**

Motivation was to fix  https://github.com/facebookincubator/create-react-app/issues/2439 and similar cases.

**Does this PR introduce a breaking change?**

This PR should not include any breaking changes: `querystring.unescape` will try to use native `decodeURIComponent` first, so it should have 1=1 behaviour on all the existing cases.

Signed-off-by: petetnt <pete.a.nykanen@gmail.com>
