### PR TITLE
fix sinon desperation

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "mocha": "^3.0.2",
     "mocha-sinon": "^2.0.0",
     "should": "^11.1.0",
-    "sinon": "^2.3.5",
+    "sinon": "^2.3.8",
     "supertest": "^3.0.0",
     "webpack": "^3.0.0"
   },

--- a/test/CompilerCallbacks.test.js
+++ b/test/CompilerCallbacks.test.js
@@ -16,7 +16,7 @@ describe("CompilerCallbacks", function() {
 
 	it("watch error should be reported to console", function(done) {
 		var error = new Error("Oh noes!");
-		this.sinon.stub(compiler, "watch", function(opts, callback) {
+		this.sinon.stub(compiler, "watch").callsFake(function(opts, callback) {
 			callback(error);
 		});
 		this.sinon.stub(console, "error");
@@ -27,7 +27,7 @@ describe("CompilerCallbacks", function() {
 	});
 
 	it("options.error should be used on watch error", function(done) {
-		this.sinon.stub(compiler, "watch", function(opts, callback) {
+		this.sinon.stub(compiler, "watch").callsFake(function(opts, callback) {
 			callback(new Error("Oh noes!"));
 		});
 		middleware(compiler, {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
fix desperation method.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests. -->

**Summary**
`sandbox.stub(obj, 'meth', val)` is deprecated and will be removed from the public API in a future version of sinon.
 Use `sandbox.stub(obj, 'meth').callsFake(fn)` instead in order to stub a function.
 Use `sandbox.stub(obj, 'meth').value(fn)` instead in order to stub a non-function value.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
