### PR TITLE
fix koa status code default set to 404

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -76,8 +76,6 @@ module.exports = function(compiler, options) {
 						res.setHeader(name, context.options.headers[name]);
 					}
 				}
-				// Express automatically sets the statusCode to 200, but not all servers do (Koa).
-				res.statusCode = res.statusCode || 200;
 				if(res.send) res.send(content);
 				else res.end(content);
 				resolve();

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "webpack": "^1.0.0 || ^2.0.0 || ^3.0.0"
   },
   "dependencies": {
+    "koa": "^2.3.0",
     "memory-fs": "~0.4.1",
     "mime": "^1.3.4",
     "path-is-absolute": "^1.0.0",

--- a/test/Koa.test.js
+++ b/test/Koa.test.js
@@ -1,0 +1,457 @@
+var middleware = require("../middleware");
+var Koa = require("koa");
+var webpack = require("webpack");
+var should = require("should");
+var request = require("supertest");
+var webpackConfig = require("./fixtures/server-test/webpack.config");
+var webpackMultiConfig = require("./fixtures/server-test/webpack.array.config");
+
+
+describe("Koa Server", function() {
+	var server;
+	var app;
+
+	function listenShorthand(done) {
+		return app.listen(8000, "127.0.0.1", function(err) {
+			if(err) done(err);
+			done();
+		});
+	}
+
+	function close(done) {
+		if(server) {
+			server.close(done);
+		} else {
+			done();
+		}
+	}
+
+	describe("requests", function() {
+		before(function(done) {
+			app = new Koa();
+			var compiler = webpack(webpackConfig);
+			var instance = middleware(compiler, {
+				stats: "errors-only",
+				quiet: true,
+				publicPath: "/public/",
+			});
+			function waitMiddleware() {
+				return new Promise((resolve, reject) => {
+					instance.waitUntilValid(() => {
+						resolve(true);
+					});
+
+					compiler.plugin("failed", (error) => {
+						reject(error);
+					});
+				});
+			}
+			app.use((ctx, next) => {
+				return waitMiddleware().then(() => {
+					var res = {
+						locals: ctx.state,
+						send(content) {
+							ctx.body = content;
+						},
+						setHeader(field, value) {
+							ctx.set(field, value);
+						},
+						get statusCode() {
+							return ctx.status;
+						},
+						set statusCode(code) {
+							ctx.status = code;
+						}
+					};
+					return instance(ctx.req, res, next);
+				});
+			});
+			server = listenShorthand(done);
+			// Hack to add a mock HMR json file to the in-memory filesystem.
+			instance.fileSystem.writeFileSync("/123a123412.hot-update.json", "[\"hi\"]");
+		});
+		after(close);
+
+		it("GET request to bundle file", function(done) {
+			request(server).get("/public/bundle.js")
+				.expect("Content-Type", "application/javascript; charset=UTF-8")
+				.expect("Content-Length", "2823")
+				.expect(200, /console\.log\("Hey\."\)/, done);
+		});
+
+		it("POST request to bundle file", function(done) {
+			request(server).post("/public/bundle.js")
+				.expect(404, done);
+		});
+
+		it("request to image", function(done) {
+			request(server).get("/public/svg.svg")
+				.expect("Content-Type", "image/svg+xml; charset=UTF-8")
+				.expect("Content-Length", "4778")
+				.expect(200, done);
+		});
+
+		it("request to non existing file", function(done) {
+			request(server).get("/public/nope")
+				.expect("Content-Type", "text/plain; charset=utf-8")
+				.expect(404, done);
+		});
+
+		it("request to HMR json", function(done) {
+			request(server).get("/public/123a123412.hot-update.json")
+				.expect("Content-Type", "application/json; charset=UTF-8")
+				.expect(200, /\[\"hi\"\]/, done);
+		});
+
+		it("request to directory", function(done) {
+			request(server).get("/public/")
+				.expect("Content-Type", "text/html; charset=UTF-8")
+				.expect("Content-Length", "10")
+				.expect(200, /My\ Index\./, done);
+		});
+
+		it("invalid range header", function(done) {
+			request(server).get("/public/svg.svg")
+				.set("Range", "bytes=6000-")
+				.expect(416, done);
+		});
+
+		it("valid range header", function(done) {
+			request(server).get("/public/svg.svg")
+				.set("Range", "bytes=3000-3500")
+				.expect("Content-Length", "501")
+				.expect("Content-Range", "bytes 3000-3500/4778")
+				.expect(206, done);
+		});
+
+		it("request to non-public path", function(done) {
+			request(server).get("/nonpublic/")
+				.expect("Content-Type", "text/plain; charset=utf-8")
+				.expect(404, done);
+		});
+	});
+
+	describe("no index mode", function() {
+		before(function(done) {
+			app = new Koa();
+			var compiler = webpack(webpackConfig);
+			var instance = middleware(compiler, {
+				stats: "errors-only",
+				quiet: true,
+				index: false,
+				publicPath: "/",
+			});
+			function waitMiddleware() {
+				return new Promise((resolve, reject) => {
+					instance.waitUntilValid(() => {
+						resolve(true);
+					});
+
+					compiler.plugin("failed", (error) => {
+						reject(error);
+					});
+				});
+			}
+			app.use((ctx, next) => {
+				return waitMiddleware().then(() => {
+					var res = {
+						locals: ctx.state,
+						send(content) {
+							ctx.body = content;
+						},
+						setHeader(field, value) {
+							ctx.set(field, value);
+						},
+						get statusCode() {
+							return ctx.status;
+						},
+						set statusCode(code) {
+							ctx.status = code;
+						}
+					};
+					return instance(ctx.req, res, next);
+				});
+			});
+			server = listenShorthand(done);
+		});
+		after(close);
+
+		it("request to directory", function(done) {
+			request(server).get("/")
+				.expect("Content-Type", "text/plain; charset=utf-8")
+				.expect(404, done);
+		});
+	});
+
+	describe("lazy mode", function() {
+		before(function(done) {
+			app = new Koa();
+			var compiler = webpack(webpackConfig);
+			var instance = middleware(compiler, {
+				stats: "errors-only",
+				quiet: true,
+				lazy: true,
+				publicPath: "/",
+			});
+			function waitMiddleware() {
+				return new Promise((resolve, reject) => {
+					instance.waitUntilValid(() => {
+						resolve(true);
+					});
+
+					compiler.plugin("failed", (error) => {
+						reject(error);
+					});
+				});
+			}
+			app.use((ctx, next) => {
+				return waitMiddleware().then(() => {
+					var res = {
+						locals: ctx.state,
+						send(content) {
+							ctx.body = content;
+						},
+						setHeader(field, value) {
+							ctx.set(field, value);
+						},
+						get statusCode() {
+							return ctx.status;
+						},
+						set statusCode(code) {
+							ctx.status = code;
+						}
+					};
+					return instance(ctx.req, res, next);
+				});
+			});
+			server = listenShorthand(done);
+		});
+		after(close);
+
+		it("GET request to bundle file", function(done) {
+			request(server).get("/bundle.js")
+				.expect("Content-Length", "2823")
+				.expect(200, /console\.log\("Hey\."\)/, done);
+		});
+	});
+
+	describe("custom headers", function() {
+		before(function(done) {
+			app = new Koa();
+			var compiler = webpack(webpackConfig);
+			var instance = middleware(compiler, {
+				stats: "errors-only",
+				quiet: true,
+				headers: { "X-nonsense-1": "yes", "X-nonsense-2": "no" }
+			});
+			function waitMiddleware() {
+				return new Promise((resolve, reject) => {
+					instance.waitUntilValid(() => {
+						resolve(true);
+					});
+
+					compiler.plugin("failed", (error) => {
+						reject(error);
+					});
+				});
+			}
+			app.use((ctx, next) => {
+				return waitMiddleware().then(() => {
+					var res = {
+						locals: ctx.state,
+						send(content) {
+							ctx.body = content;
+						},
+						setHeader(field, value) {
+							ctx.set(field, value);
+						},
+						get statusCode() {
+							return ctx.status;
+						},
+						set statusCode(code) {
+							ctx.status = code;
+						}
+					};
+					return instance(ctx.req, res, next);
+				});
+			});
+			server = listenShorthand(done);
+		});
+		after(close);
+
+		it("request to bundle file", function(done) {
+			request(server).get("/bundle.js")
+				.expect("X-nonsense-1", "yes")
+				.expect("X-nonsense-2", "no")
+				.expect(200, done);
+		});
+	});
+
+	describe("custom mimeTypes", function() {
+		before(function(done) {
+			app = new Koa();
+			var compiler = webpack(webpackConfig);
+			var instance = middleware(compiler, {
+				stats: "errors-only",
+				quiet: true,
+				index: "Index.phtml",
+				mimeTypes: {
+					"text/html": ["phtml"]
+				}
+			});
+			function waitMiddleware() {
+				return new Promise((resolve, reject) => {
+					instance.waitUntilValid(() => {
+						resolve(true);
+					});
+
+					compiler.plugin("failed", (error) => {
+						reject(error);
+					});
+				});
+			}
+			app.use((ctx, next) => {
+				return waitMiddleware().then(() => {
+					var res = {
+						locals: ctx.state,
+						send(content) {
+							ctx.body = content;
+						},
+						setHeader(field, value) {
+							ctx.set(field, value);
+						},
+						get statusCode() {
+							return ctx.status;
+						},
+						set statusCode(code) {
+							ctx.status = code;
+						}
+					};
+					return instance(ctx.req, res, next);
+				});
+			});
+			server = listenShorthand(done);
+			instance.fileSystem.writeFileSync("/Index.phtml", "welcome");
+		});
+		after(close);
+
+		it("request to Index.phtml", function(done) {
+			request(server).get("/")
+				.expect("welcome")
+				.expect("Content-Type", /text\/html/)
+				.expect(200, done);
+		});
+	});
+
+	describe("MultiCompiler", function() {
+		before(function(done) {
+			app = new Koa();
+			var compiler = webpack(webpackMultiConfig);
+			var instance = middleware(compiler, {
+				stats: "errors-only",
+				quiet: true,
+				publicPath: "/"
+			});
+			function waitMiddleware() {
+				return new Promise((resolve, reject) => {
+					instance.waitUntilValid(() => {
+						resolve(true);
+					});
+
+					compiler.plugin("failed", (error) => {
+						reject(error);
+					});
+				});
+			}
+			app.use((ctx, next) => {
+				return waitMiddleware().then(() => {
+					var res = {
+						locals: ctx.state,
+						send(content) {
+							ctx.body = content;
+						},
+						setHeader(field, value) {
+							ctx.set(field, value);
+						},
+						get statusCode() {
+							return ctx.status;
+						},
+						set statusCode(code) {
+							ctx.status = code;
+						}
+					};
+					return instance(ctx.req, res, next);
+				});
+			});
+			server = listenShorthand(done);
+		});
+		after(close);
+
+		it("request to both bundle files", function(done) {
+			request(server).get("/js1/foo.js")
+				.expect(200, function() {
+					request(server).get("/js2/bar.js")
+						.expect(200, done);
+				});
+		});
+	});
+
+
+	describe("server side render", function() {
+		var locals;
+		before(function(done) {
+			app = new Koa();
+			var compiler = webpack(webpackConfig);
+			var instance = middleware(compiler, {
+				stats: "errors-only",
+				quiet: true,
+				serverSideRender: true,
+			});
+			function waitMiddleware() {
+				return new Promise((resolve, reject) => {
+					instance.waitUntilValid(() => {
+						resolve(true);
+					});
+
+					compiler.plugin("failed", (error) => {
+						reject(error);
+					});
+				});
+			}
+			app.use((ctx, next) => {
+				return waitMiddleware().then(() => {
+					var res = {
+						locals: ctx.state,
+						send(content) {
+							ctx.body = content;
+						},
+						setHeader(field, value) {
+							ctx.set(field, value);
+						},
+						get statusCode() {
+							return ctx.status;
+						},
+						set statusCode(code) {
+							ctx.status = code;
+						}
+					};
+					return instance(ctx.req, res, next);
+				});
+			});
+			app.use(function(ctx) {
+				locals = ctx.state;
+				ctx.status = 200;
+			});
+			server = listenShorthand(done);
+		});
+		after(close);
+
+		it("request to bundle file", function(done) {
+			request(server).get("/foo/bar")
+				.expect(200, function() {
+					should.exist(locals.webpackStats);
+					done();
+				});
+		});
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests. -->

**Summary**
koa's [response](https://github.com/koajs/koa/blob/master/lib/response.js#L148) code has the following:
```
set status(code) {
    ...

    // set the status
    if (!this._explicitStatus) this.status = 200;

    ...
  }
```

We can see that if the `this._explicitStatus` is not `true`, koa will set the status to 200 when the set body is called. 

But if you do `res.statusCode = res.statusCode || 200`, it will cause the this._explicitStatus to become true, because koa default set status to 404, this is equal to `res.statusCode = 404`, so this will cause a problem.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
