### PR TITLE
Allow override of mimetype detection with lookupMime option

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -69,7 +69,11 @@ module.exports = function(compiler, options) {
 				// server content
 				var content = context.fs.readFileSync(filename);
 				content = shared.handleRangeHeaders(content, req, res);
-				res.setHeader("Content-Type", mime.lookup(filename) + "; charset=UTF-8");
+				if(context.options.lookupMime) {
+					res.setHeader("Content-Type", context.options.lookupMime(filename));
+				} else {
+					res.setHeader("Content-Type", mime.lookup(filename) + "; charset=UTF-8");
+				}
 				res.setHeader("Content-Length", content.length);
 				if(context.options.headers) {
 					for(var name in context.options.headers) {

--- a/test/Server.test.js
+++ b/test/Server.test.js
@@ -240,4 +240,29 @@ describe("Server", function() {
 				});
 		});
 	});
+
+	describe("mime handling", function() {
+		before(function(done) {
+			app = express();
+			var compiler = webpack(webpackConfig);
+			var instance = middleware(compiler, {
+				stats: "errors-only",
+				quiet: true,
+				publicPath: "/public/",
+				lookupMime: function() {
+					return "application/test";
+				}
+			});
+			app.use(instance);
+			listen = listenShorthand(done);
+		});
+		after(close);
+
+		it("allows override of mimeTypes", function(done) {
+			request(app).get("/public/bundle.js")
+				.expect("Content-Type", "application/test")
+				.expect("Content-Length", "2823")
+				.expect(200, /console\.log\("Hey\."\)/, done);
+		});
+	});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Adds a lookupMime option so users can add custom mime type handling.

**Did you add tests for your changes?**

Yes.

**Summary**

The default behavior of inferring mime-types from the file extension may not be sufficient for all needs. For example, solving https://github.com/callstack-io/haul/issues/228 requires a messy workaround.

**Does this PR introduce a breaking change?**

No. Things should work fine for existing users (assuming tests are fine).

**Other information**