### PR TITLE
serve .wasm files as application/wasm (without charset)

### DIFF
--- a/lib/Shared.js
+++ b/lib/Shared.js
@@ -32,6 +32,10 @@ module.exports = function Shared(context) {
 					options.filename = new RegExp("^[\/]{0,1}" + str + "$");
 				}
 			}
+			// add MIME type for WebAssembly
+			mime.define({
+				"application/wasm": ["wasm"]
+			});
 			// defining custom MIME type
 			if(options.mimeTypes) mime.define(options.mimeTypes);
 

--- a/lib/Shared.js
+++ b/lib/Shared.js
@@ -32,10 +32,6 @@ module.exports = function Shared(context) {
 					options.filename = new RegExp("^[\/]{0,1}" + str + "$");
 				}
 			}
-			// add MIME type for WebAssembly
-			mime.define({
-				"application/wasm": ["wasm"]
-			});
 			// defining custom MIME type
 			if(options.mimeTypes) mime.define(options.mimeTypes);
 

--- a/middleware.js
+++ b/middleware.js
@@ -69,7 +69,12 @@ module.exports = function(compiler, options) {
 				// server content
 				var content = context.fs.readFileSync(filename);
 				content = shared.handleRangeHeaders(content, req, res);
-				res.setHeader("Content-Type", mime.lookup(filename) + "; charset=UTF-8");
+				var contentType = mime.lookup(filename);
+				// do not add charset to WebAssembly files, otherwise compileStreaming will fail in the client
+				if(!/\.wasm$/.test(filename)) {
+					contentType += "; charset=UTF-8";
+				}
+				res.setHeader("Content-Type", contentType);
 				res.setHeader("Content-Length", content.length);
 				if(context.options.headers) {
 					for(var name in context.options.headers) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "memory-fs": "~0.4.1",
-    "mime": "^1.4.1",
+    "mime": "^1.5.0",
     "path-is-absolute": "^1.0.0",
     "range-parser": "^1.0.3",
     "time-stamp": "^2.0.0"

--- a/test/Server.test.js
+++ b/test/Server.test.js
@@ -190,6 +190,28 @@ describe("Server", function() {
 		});
 	});
 
+	describe("WebAssembly", function() {
+		before(function(done) {
+			app = express();
+			var compiler = webpack(webpackConfig);
+			var instance = middleware(compiler, {
+				stats: "errors-only",
+				quiet: true
+			});
+			app.use(instance);
+			listen = listenShorthand(done);
+			instance.fileSystem.writeFileSync("/hello.wasm", "welcome");
+		});
+		after(close);
+
+		it("request to hello.wasm", function(done) {
+			request(app).get("/hello.wasm")
+				.expect("welcome")
+				.expect("Content-Type", "application/wasm")
+				.expect(200, done);
+		});
+	});
+
 	describe("MultiCompiler", function() {
 		before(function(done) {
 			app = express();


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Adds support for correctly serving .wasm files when using webpack/next WebAssembly support

**Did you add tests for your changes?**

yes

**Summary**

Changes middleware so it does not add charset to application/wasm MIME type, which solves #229

**Does this PR introduce a breaking change?**

No
