### PR TITLE
fixed name of logging lib and added link

### DIFF
--- a/breaking-changes.md
+++ b/breaking-changes.md
@@ -7,7 +7,7 @@ that date.
 
 ## Informative Changes
 
-- logging is now handled by `log-level` and follows the same patterns as
+- logging is now handled by [`loglevel`](https://www.npmjs.com/package/loglevel) and follows the same patterns as
 `webpack-dev-server`.
 
 ## Breaking Changes


### PR DESCRIPTION
Looking at the `package.json` it seems that the correct logging lib is [`loglevel`](https://www.npmjs.com/package/loglevel). This can be important, because there is actually a package called [`log-level`](https://www.npmjs.com/package/log-level) as well 😁