### PR TITLE
Allow sniffing of mime types based on content.

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const mime = require('mime');
+const detectContentType = require('detect-content-type');
 const urlJoin = require('url-join');
 const { getFilenameFromUrl, handleRangeHeaders, handleRequest, ready } = require('./util');
 
@@ -62,14 +63,21 @@ module.exports = function wrapper(context) {
 
         // server content
         let content = context.fs.readFileSync(filename);
-        content = handleRangeHeaders(content, req, res);
+
         let contentType = mime.getType(filename);
-        // do not add charset to WebAssembly files, otherwise compileStreaming will fail in the client
-        if (!/\.wasm$/.test(filename)) {
-          contentType += '; charset=UTF-8';
+        if (contentType !== null) {
+          // do not add charset to WebAssembly files, otherwise compileStreaming will fail in the client
+          if (!/\.wasm$/.test(filename)) {
+            contentType += '; charset=UTF-8';
+          }
+        } else {
+          // Perform MIME sniffing if contentType is null
+          contentType = detectContentType(content);
         }
 
         res.setHeader('Content-Type', contentType);
+
+        content = handleRangeHeaders(content, req, res);
         res.setHeader('Content-Length', content.length);
 
         const { headers } = context.options;

--- a/package-lock.json
+++ b/package-lock.json
@@ -644,6 +644,11 @@
         "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
       }
     },
+    "detect-content-type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/detect-content-type/-/detect-content-type-1.2.0.tgz",
+      "integrity": "sha512-YCBxuqJLY9rMxV44Ict2kNgjYFN3v1dnsn6sJvd6sUwwU1TWP3D+K2dr/S9AF/fio2/RsAKYdRiEOtNoRbmiag=="
+    },
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
   },
   "dependencies": {
+    "detect-content-type": "^1.2.0",
     "loud-rejection": "^1.6.0",
     "memory-fs": "~0.4.1",
     "mime": "^2.1.0",

--- a/test/fixtures/server-test/foo.js
+++ b/test/fixtures/server-test/foo.js
@@ -2,5 +2,6 @@
 
 require('./svg.svg');
 require('./index.html');
+require('./htmlnoext');
 
 console.log('Hey.');

--- a/test/fixtures/server-test/htmlnoext
+++ b/test/fixtures/server-test/htmlnoext
@@ -1,0 +1,1 @@
+<html><body></body></html>

--- a/test/fixtures/server-test/webpack.config.js
+++ b/test/fixtures/server-test/webpack.config.js
@@ -13,6 +13,11 @@ module.exports = {
         test: /\.(svg|html)$/,
         loader: 'file-loader',
         query: { name: '[name].[ext]' }
+      },
+      {
+        test: /htmlnoext/,
+        loader: 'file-loader',
+        query: { name: 'htmlnoext' }
       }
     ]
   }

--- a/test/tests/server.js
+++ b/test/tests/server.js
@@ -52,7 +52,7 @@ describe('Server', () => {
     it('GET request to bundle file', (done) => {
       request(app).get('/public/bundle.js')
         .expect('Content-Type', 'application/javascript; charset=UTF-8')
-        .expect('Content-Length', '2839')
+        .expect('Content-Length', '2993')
         .expect(200, /console\.log\('Hey\.'\)/, done);
     });
 
@@ -67,6 +67,12 @@ describe('Server', () => {
         .expect('Content-Length', '4778')
         .expect(200, done);
     });
+
+    it('request to HTML file with no extension', (done) => {
+      request(app).get('/public/htmlnoext')
+        .expect('Content-Type', 'text/html; charset=utf-8')
+        .expect(200, done);
+    })
 
     it('request to non existing file', (done) => {
       request(app).get('/public/nope')
@@ -147,7 +153,7 @@ describe('Server', () => {
 
     it('GET request to bundle file', (done) => {
       request(app).get('/bundle.js')
-        .expect('Content-Length', '2839')
+        .expect('Content-Length', '2993')
         .expect(200, /console\.log\('Hey\.'\)/, done);
     });
   });


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature

**Did you add tests for your changes?**
Yes.

I added a single static file to the fixtures, but I need some help in hooking
it up with the server tests. I hope the current way I have done it, is okay.

**Summary**
If the original file being served does not have an extension, MIME
type detection based on file name fails and the MIME type defaults
to `null`.

I originally encountered this problem in Gatsby, the static site generator. I was trying
to generate HTML files with no extension and trying to access it (like `http://localhost:8080/Hello`)
and it would get served with the `application/octet-stream` MIME type because it had no extension.

This change adds code to check if a filename has no extension and perform MIME type sniffing
using the [detect-content-type] NPM module (which I created explicitly for this purpose).

[detect-content-type]: https://www.npmjs.com/package/detect-content-type

**Does this PR introduce a breaking change?**
Not that I can see, but if it is preferable I can put this functionality behind an option so that it can be turned on and off.