### PR TITLE
Fix getPaths for publicPaths that are URLs (#255)

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -24,12 +24,11 @@ function getPaths(publicPath, compiler, url) {
     && compilers[i].options.output
     && compilers[i].options.output.publicPath;
 
-      // handle the case where compilerPublicPath is a URL with hostname
       if (compilerPublicPath.startsWith('/')) {
         compilerPublicPathBase = compilerPublicPath;
       } else {
-        const urlObject = parse(compilerPublicPath);
-        compilerPublicPathBase = urlObject.pathname;
+        // handle the case where compilerPublicPath is a URL with hostname
+        compilerPublicPathBase = parse(compilerPublicPath).pathname;
       }
 
       // check the url vs the path part of the compilerPublicPath

--- a/lib/util.js
+++ b/lib/util.js
@@ -24,7 +24,7 @@ function getPaths(publicPath, compiler, url) {
     && compilers[i].options.output
     && compilers[i].options.output.publicPath;
 
-      if (compilerPublicPath.startsWith('/')) {
+      if (compilerPublicPath.indexOf('/') === 0) {
         compilerPublicPathBase = compilerPublicPath;
       } else {
         // handle the case where compilerPublicPath is a URL with hostname

--- a/lib/util.js
+++ b/lib/util.js
@@ -15,11 +15,25 @@ function getPaths(publicPath, compiler, url) {
   const compilers = compiler && compiler.compilers;
   if (Array.isArray(compilers)) {
     let compilerPublicPath;
+
+    // the path portion of compilerPublicPath
+    let compilerPublicPathBase;
+
     for (let i = 0; i < compilers.length; i++) {
       compilerPublicPath = compilers[i].options
     && compilers[i].options.output
     && compilers[i].options.output.publicPath;
-      if (url.indexOf(compilerPublicPath) === 0) {
+
+      // handle the case where compilerPublicPath is a URL with hostname
+      if (compilerPublicPath.startsWith('/')) {
+        compilerPublicPathBase = compilerPublicPath;
+      } else {
+        const urlObject = parse(compilerPublicPath);
+        compilerPublicPathBase = urlObject.pathname;
+      }
+
+      // check the url vs the path part of the compilerPublicPath
+      if (url.indexOf(compilerPublicPathBase) === 0) {
         return {
           publicPath: compilerPublicPath,
           outputPath: compilers[i].outputPath

--- a/test/tests/util.js
+++ b/test/tests/util.js
@@ -132,10 +132,30 @@ describe('GetFilenameFromUrl', () => {
       expected: '/foo/sample.js'
     },
     {
+      url: '/js/sample.js',
+      compilers: [
+        { outputPath: '/foo', options: { output: { publicPath: 'http://localhost/js/' } } },
+        { outputPath: '/bar', options: { output: { publicPath: 'http://localhost/css/' } } }
+      ],
+      outputPath: '/root',
+      publicPath: '/',
+      expected: '/foo/sample.js'
+    },
+    {
       url: '/css/sample.css',
       compilers: [
         { outputPath: '/foo', options: { output: { publicPath: '/js/' } } },
         { outputPath: '/bar', options: { output: { publicPath: '/css/' } } }
+      ],
+      outputPath: '/root',
+      publicPath: '/',
+      expected: '/bar/sample.css'
+    },
+    {
+      url: '/css/sample.css',
+      compilers: [
+        { outputPath: '/foo', options: { output: { publicPath: 'http://localhost/js/' } } },
+        { outputPath: '/bar', options: { output: { publicPath: 'http://localhost/css/' } } }
       ],
       outputPath: '/root',
       publicPath: '/',
@@ -152,10 +172,30 @@ describe('GetFilenameFromUrl', () => {
       expected: '/root/other/sample.txt'
     },
     {
+      url: '/other/sample.txt',
+      compilers: [
+        { outputPath: '/foo', options: { output: { publicPath: 'http://localhost/js/' } } },
+        { outputPath: '/bar', options: { output: { publicPath: 'http://localhost/css/' } } }
+      ],
+      outputPath: '/root',
+      publicPath: '/',
+      expected: '/root/other/sample.txt'
+    },
+    {
       url: '/js/sample.js',
       compilers: [
         { outputPath: '/foo', options: { output: { publicPath: '/js/' } } },
         { outputPath: '/bar', options: { output: { publicPath: '/css/' } } }
+      ],
+      outputPath: '/root',
+      publicPath: '/test/',
+      expected: '/foo/sample.js'
+    },
+    {
+      url: '/js/sample.js',
+      compilers: [
+        { outputPath: '/foo', options: { output: { publicPath: 'http://localhost/js/' } } },
+        { outputPath: '/bar', options: { output: { publicPath: 'http://localhost/css/' } } }
       ],
       outputPath: '/root',
       publicPath: '/test/',
@@ -172,6 +212,16 @@ describe('GetFilenameFromUrl', () => {
       expected: '/bar/sample.css'
     },
     {
+      url: '/css/sample.css',
+      compilers: [
+        { outputPath: '/foo', options: { output: { publicPath: 'http://localhost/js/' } } },
+        { outputPath: '/bar', options: { output: { publicPath: 'http://localhost/css/' } } }
+      ],
+      outputPath: '/root',
+      publicPath: '/test/',
+      expected: '/bar/sample.css'
+    },
+    {
       url: '/other/sample.txt',
       compilers: [
         { outputPath: '/foo', options: { output: { publicPath: '/js/' } } },
@@ -182,10 +232,30 @@ describe('GetFilenameFromUrl', () => {
       expected: false
     },
     {
+      url: '/other/sample.txt',
+      compilers: [
+        { outputPath: '/foo', options: { output: { publicPath: 'http://localhost/js/' } } },
+        { outputPath: '/bar', options: { output: { publicPath: 'http://localhost/css/' } } }
+      ],
+      outputPath: '/root',
+      publicPath: '/test/',
+      expected: false
+    },
+    {
       url: '/test/sample.txt',
       compilers: [
         { outputPath: '/foo', options: { output: { publicPath: '/js/' } } },
         { outputPath: '/bar', options: { output: { publicPath: '/css/' } } }
+      ],
+      outputPath: '/root',
+      publicPath: '/test/',
+      expected: '/root/sample.txt'
+    },
+    {
+      url: '/test/sample.txt',
+      compilers: [
+        { outputPath: '/foo', options: { output: { publicPath: 'http://localhost/js/' } } },
+        { outputPath: '/bar', options: { output: { publicPath: 'http://localhost/css/' } } }
       ],
       outputPath: '/root',
       publicPath: '/test/',


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fixes #255 by using only the path part of `compilerPublicPath` for checking against `url`.

**Did you add tests for your changes?**

Tests were added which correspond to existing tests for the same functionality.

**Summary**

This fixes an issue I was seeing with `webpack-dev-server` where it would not select the correct compiler from the list to serve the bundle.

**Does this PR introduce a breaking change?**

I don't think this should introduce a breaking change since the use case this addresses currently does not work.