### PR TITLE
fixes #258: skip compilers with no publicPath

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -21,8 +21,8 @@ function getPaths(publicPath, compiler, url) {
 
     for (let i = 0; i < compilers.length; i++) {
       compilerPublicPath = compilers[i].options
-        && compilers[i].options.output
-        && compilers[i].options.output.publicPath;
+    && compilers[i].options.output
+    && compilers[i].options.output.publicPath;
 
       if (compilerPublicPath) {
         if (compilerPublicPath.indexOf('/') === 0) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -21,22 +21,24 @@ function getPaths(publicPath, compiler, url) {
 
     for (let i = 0; i < compilers.length; i++) {
       compilerPublicPath = compilers[i].options
-    && compilers[i].options.output
-    && compilers[i].options.output.publicPath;
+        && compilers[i].options.output
+        && compilers[i].options.output.publicPath;
 
-      if (compilerPublicPath.indexOf('/') === 0) {
-        compilerPublicPathBase = compilerPublicPath;
-      } else {
-        // handle the case where compilerPublicPath is a URL with hostname
-        compilerPublicPathBase = parse(compilerPublicPath).pathname;
-      }
+      if (compilerPublicPath) {
+        if (compilerPublicPath.indexOf('/') === 0) {
+          compilerPublicPathBase = compilerPublicPath;
+        } else {
+          // handle the case where compilerPublicPath is a URL with hostname
+          compilerPublicPathBase = parse(compilerPublicPath).pathname;
+        }
 
-      // check the url vs the path part of the compilerPublicPath
-      if (url.indexOf(compilerPublicPathBase) === 0) {
-        return {
-          publicPath: compilerPublicPath,
-          outputPath: compilers[i].outputPath
-        };
+        // check the url vs the path part of the compilerPublicPath
+        if (url.indexOf(compilerPublicPathBase) === 0) {
+          return {
+            publicPath: compilerPublicPath,
+            outputPath: compilers[i].outputPath
+          };
+        }
       }
     }
   }

--- a/test/fixtures/server-test/webpack.client.server.config.js
+++ b/test/fixtures/server-test/webpack.client.server.config.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = [{
+  context: __dirname,
+  entry: './foo.js',
+  output: {
+    filename: 'foo.js',
+    path: '/client',
+    publicPath: '/static/'
+  }
+}, {
+  context: __dirname,
+  entry: './bar.js',
+  output: {
+    filename: 'bar.js',
+    path: '/server'
+  }
+}];

--- a/test/tests/server.js
+++ b/test/tests/server.js
@@ -9,6 +9,7 @@ const request = require('supertest');
 const middleware = require('../../');
 const webpackConfig = require('../fixtures/server-test/webpack.config');
 const webpackMultiConfig = require('../fixtures/server-test/webpack.array.config');
+const webpackClientServerConfig = require('../fixtures/server-test/webpack.client.server.config');
 
 describe('Server', () => {
   let instance;
@@ -242,6 +243,28 @@ describe('Server', () => {
           request(app).get('/js2/bar.js')
             .expect(200, done);
         });
+    });
+  });
+
+  describe('MultiCompiler: One `publicPath`', () => {
+    before((done) => {
+      app = express();
+      const compiler = webpack(webpackClientServerConfig);
+      instance = middleware(compiler, {
+        stats: 'errors-only',
+        logLevel: 'silent'
+      });
+      app.use(instance);
+      listen = listenShorthand(done);
+    });
+    after(close);
+
+    it('request to bundle file', (done) => {
+      request(app).get('/static/foo.js').expect(200, done);
+    });
+
+    it('request to non-public path', (done) => {
+      request(app).get('/').expect(404, done);
     });
   });
 

--- a/test/tests/server.js
+++ b/test/tests/server.js
@@ -263,6 +263,10 @@ describe('Server', () => {
       request(app).get('/static/foo.js').expect(200, done);
     });
 
+    it('request to nonexistent file', (done) => {
+      request(app).get('/static/invalid.js').expect(404, done);
+    });
+
     it('request to non-public path', (done) => {
       request(app).get('/').expect(404, done);
     });


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes #258.

**Did you add tests for your changes?**
Yes, both 200 and 404 cases.

**Summary**
This fixes a crash when accessing a path outside of publicPath, in a multi-compiler setup, when one of the compiler configs does not include a publicPath. This can occur when using universal rendering through https://github.com/60frames/webpack-hot-server-middleware.

**Does this PR introduce a breaking change?**
No.

**Other information**
