### PR TITLE
support webpack v4

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -94,10 +94,10 @@ module.exports = function ctx(compiler, options) {
   }
 
   context.rebuild = rebuild;
-  context.compiler.plugin('invalid', invalid);
-  context.compiler.plugin('run', invalid);
+  context.compiler.hooks.invalid.tap({name: 'CopyPlugin'}, invalid)
+  context.compiler.hooks.run.tap({name: 'CopyPlugin'}, invalid)
 
-  context.compiler.plugin('done', (stats) => {
+  context.compiler.hooks.done.tap({name: 'CopyPlugin'}, (stats) => {
     // clean up the time offset
     if (options.watchOffset > 0) {
       stats.startTime -= options.watchOffset;
@@ -106,7 +106,7 @@ module.exports = function ctx(compiler, options) {
     done(stats);
   });
 
-  context.compiler.plugin('watch-run', (watcher, callback) => {
+  context.compiler.hooks.watchRun.tap({name: 'CopyPlugin'}, (watcher, callback) => {
     // apply a fix for compiler.watch, if watchOffset is greater than 0:
     //   ff0000-ad-tech/wp-plugin-watch-offset
     // offset start-time


### PR DESCRIPTION
upgrade to new tapable hooks API

**Summary**

deprecation warnings appear if using the old API

**Does this PR introduce a breaking change?**

yes,webpack v4 only