### PR TITLE
Update webpack peerDependency in v1-stable branch to v4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "7"
   - "8"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
   "peerDependencies": {
-    "webpack": "^1.0.0 || ^2.0.0 || ^3.0.0"
+    "webpack": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "dependencies": {
     "memory-fs": "~0.4.1",
@@ -17,14 +17,14 @@
     "codecov.io": "^0.1.6",
     "eslint": "^4.0.0",
     "express": "^4.14.0",
-    "file-loader": "^0.11.2",
+    "file-loader": "^1.1.9",
     "istanbul": "^0.4.5",
     "mocha": "^3.0.2",
     "mocha-sinon": "^2.0.0",
     "should": "^11.1.0",
     "sinon": "^2.3.8",
     "supertest": "^3.0.0",
-    "webpack": "^3.0.0"
+    "webpack": "^4.0.0"
   },
   "license": "MIT",
   "engines": {

--- a/test/Server.test.js
+++ b/test/Server.test.js
@@ -45,7 +45,7 @@ describe("Server", function() {
 		it("GET request to bundle file", function(done) {
 			request(app).get("/public/bundle.js")
 				.expect("Content-Type", "application/javascript; charset=UTF-8")
-				.expect("Content-Length", "2823")
+				.expect("Content-Length", "3435")
 				.expect(200, /console\.log\("Hey\."\)/, done);
 		});
 
@@ -138,7 +138,7 @@ describe("Server", function() {
 
 		it("GET request to bundle file", function(done) {
 			request(app).get("/bundle.js")
-				.expect("Content-Length", "2823")
+				.expect("Content-Length", "3435")
 				.expect(200, /console\.log\("Hey\."\)/, done);
 		});
 	});

--- a/test/fixtures/server-test/webpack.config.js
+++ b/test/fixtures/server-test/webpack.config.js
@@ -1,4 +1,6 @@
 module.exports = {
+	mode: "development",
+	devtool: false,
 	context: __dirname,
 	entry: "./foo.js",
 	output: {
@@ -6,7 +8,7 @@ module.exports = {
 		path: "/"
 	},
 	module: {
-		loaders: [
+		rules: [
 			{
 				test: /\.(svg|html)$/,
 				loader: "file-loader",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This adds webpack v4 as a devDependency, updates the file-loader dependency to fix tests, updates the config schema used in the server-tests, and adds webpack ^4.0.0 to supported `peerDependencies`.

**Did you add tests for your changes?**

No, but I fixed broken tests resulting from this change.

**Summary**

This pull request aims to add webpack v4 support to the 1.x versions of webpack-dev-middleware for projects which have not yet updated to 2.x.

See issue: #263 

**Does this PR introduce a breaking change?**

No.

**Other information**

I have updated the webpack `devDependency` and the `peerDependency` config, and ensured that all tests pass.  I have not, however, changed the version number in package.json for a v1.13 release.

Closes: #263 
/cc @shellscape 