### PR TITLE
Don't add / to url when in Windows

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -9,6 +9,7 @@ const urlJoin = require('url-join');
 const DevMiddlewareError = require('./DevMiddlewareError');
 
 const HASH_REGEXP = /[0-9a-f]{10,}/;
+const isWindows = process && (process.platform === 'win32' || /^(msys|cygwin)$/.test(process.env.OSTYPE));
 
 // support for multi-compiler configuration
 // see: https://github.com/webpack/webpack-dev-server/issues/641
@@ -93,7 +94,7 @@ module.exports = {
     if (filename) {
       uri = urlJoin((outputPath || ''), filename);
 
-      if (!uri.startsWith('/')) {
+      if (!isWindows && !uri.startsWith('/')) {
         uri = `/${uri}`;
       }
     }


### PR DESCRIPTION
Adds an aditional check for Windows platform when processing assets URL.


**Did you add tests for your changes?**
No

**Summary**

Fixes #270 