### PR TITLE
Fix Windows Paths

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -93,7 +93,7 @@ module.exports = {
     if (filename) {
       uri = urlJoin((outputPath || ''), filename);
 
-      if (!pathabs(uri)) {
+      if (!pathabs.posix(uri) && !pathabs.win32(uri)) {
         uri = `/${uri}`;
       }
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -93,7 +93,7 @@ module.exports = {
     if (filename) {
       uri = urlJoin((outputPath || ''), filename);
 
-      if (!uri.startsWith('/')) {
+      if (!pathabs(uri)) {
         uri = `/${uri}`;
       }
     }

--- a/test/tests/util.js
+++ b/test/tests/util.js
@@ -125,7 +125,8 @@ describe('GetFilenameFromUrl', () => {
       url: '/test/windows.txt',
       outputPath: 'c:\\foo',
       publicPath: '/test',
-      expected: 'c://\\foo/windows.txt' // this is weird, but it's legal-ish, and what URI parsing produces
+      // this is weird, but it's legal-ish, and what URI parsing produces
+      expected: 'c://\\foo/windows.txt'
     },
     {
       url: '/js/sample.js',

--- a/test/tests/util.js
+++ b/test/tests/util.js
@@ -122,6 +122,12 @@ describe('GetFilenameFromUrl', () => {
       expected: '/pathname with spaces.js'
     },
     {
+      url: '/test/windows.txt',
+      outputPath: 'c:\\foo',
+      publicPath: '/test',
+      expected: 'c://\\foo/windows.txt' // this is weird, but it's legal-ish, and what URI parsing produces
+    },
+    {
       url: '/js/sample.js',
       compilers: [
         { outputPath: '/foo', options: { output: { publicPath: '/js/' } } },


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix for #270 .

**Did you add tests for your changes?**

Test added for the Windows path that will be generated after this fix.

Where we might expect `c:\foo\bar` we instead get a URL-ized `c://\foo/bar`. Either works with the default path translation on Windows, though *technically* it's wrong.

**Summary**

Allows using webpack-dev-middleware on Windows. Without this, the path generated is along the lines of `/c:\foo/bar` which is then translated by Windows as `c:\c:\foo\bar` under the hood, which won't resolve properly.

**Does this PR introduce a breaking change?**

Not that I'm aware of. It's possible that someone using a very non-idiomatic path on a POSIX system might have problems, maybe.

**Other information**

I wouldn't call this the best possible fix, but It Werks(tm). A more correct change would run much deeper, perhaps requiring modifications to the file system abstraction in Webpack itself.