### PR TITLE
Clarify best practice: Use `webpackConfig.output.publicPath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,7 @@ eg. `{ 'text/html': [ 'phtml' ] }`. Please see the documentation for
 Type: `String`  
 _Required_
 
-The public path that the middleware is bound to. _Best Practice: use the same
-`publicPath` defined in your webpack config._
+The public path that the middleware is bound to. _Best Practice: use your webpack config's `output.publicPath` as the value for the required `publicPath`. For example, if you've required your webpack config as `webpackConfig`, declare `publicPath: webpackConfig.output.publicPath` within the options you pass to the middleware._
 
 ### reporter
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

The change is a documentation improvement.

**Did you add tests for your changes?**

No. Docs changes do not impact the implementation and thus do not require tests.

**Summary**

When installing this middleware I was surprised that `webpackDevMiddleware(webpack(webpackConfig)` didn't just work. When I reviewed the docs I realized that publicPath is required, and tried to add the publicPath to my webpack.config, but publicPath is not a root level property for this config option. Instead the publicPath is nested under the output property, and we should specify that the `output.publicPath` is the correct property to assign `publicPath` to.

**Does this PR introduce a breaking change?**

No.