### PR TITLE
On windows path spaces should resolve to %20

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -103,6 +103,7 @@ module.exports = {
     result = querystring.unescape(uri);
 
     // fixes #284, on windows path spaces should resolve to %20
+    /* istanbul ignore if */
     if (process.platform === 'win32') {
       result = result.replace(/\s/g, '%20');
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -65,6 +65,7 @@ module.exports = {
     const localPrefix = parse(publicPath || '/', false, true);
     const urlObject = parse(url);
     let filename;
+    let result = '';
 
     // publicPath has the hostname that is not the same as request url's, should fail
     if (localPrefix.hostname !== null && urlObject.hostname !== null &&
@@ -99,7 +100,14 @@ module.exports = {
     }
 
     // if no matches, use outputPath as filename
-    return querystring.unescape(uri);
+    result = querystring.unescape(uri);
+
+    // fixes #284, on windows path spaces should resolve to %20
+    if (process.platform === 'win32') {
+      result = result.replace(/\s/g, '%20');
+    }
+
+    return result;
   },
 
   handleRangeHeaders(content, req, res) {

--- a/test/test.js
+++ b/test/test.js
@@ -1,12 +1,12 @@
 'use strict';
 
 // keep the log test first, wonky sinon errors otherwise
-// require('./tests/log');
+require('./tests/log');
 
-// require('./tests/api');
-// require('./tests/compiler-callbacks');
-// require('./tests/file-system');
-// require('./tests/lazy');
-// require('./tests/reporter');
-// require('./tests/server');
+require('./tests/api');
+require('./tests/compiler-callbacks');
+require('./tests/file-system');
+require('./tests/lazy');
+require('./tests/reporter');
+require('./tests/server');
 require('./tests/util');

--- a/test/test.js
+++ b/test/test.js
@@ -1,12 +1,12 @@
 'use strict';
 
 // keep the log test first, wonky sinon errors otherwise
-require('./tests/log');
+// require('./tests/log');
 
-require('./tests/api');
-require('./tests/compiler-callbacks');
-require('./tests/file-system');
-require('./tests/lazy');
-require('./tests/reporter');
-require('./tests/server');
+// require('./tests/api');
+// require('./tests/compiler-callbacks');
+// require('./tests/file-system');
+// require('./tests/lazy');
+// require('./tests/reporter');
+// require('./tests/server');
 require('./tests/util');

--- a/test/tests/util.js
+++ b/test/tests/util.js
@@ -278,8 +278,8 @@ describe('GetFilenameFromUrl', () => {
 
   if (process.platform === 'win32') {
     const test = {
-      url: 'C:\\My%20Path\\wwwroot\\foo.js',
-      outputPath: '/',
+      url: '\\foo.js',
+      outputPath: 'C:\\My%20Path\\wwwroot\\',
       publicPath: '/',
       expected: 'C:\\My%20Path\\wwwroot\\foo.js'
     };

--- a/test/tests/util.js
+++ b/test/tests/util.js
@@ -5,11 +5,12 @@ const { getFilenameFromUrl } = require('../../lib/util');
 
 function testUrl(options) {
   const url = getFilenameFromUrl(options.publicPath, options, options.url);
+  console.log(url);
   assert.equal(url, options.expected);
 }
 
 describe('GetFilenameFromUrl', () => {
-  const tests = [ // eslint-disable-line
+  const tests = [
     {
       url: '/foo.js',
       outputPath: '/',
@@ -270,11 +271,11 @@ describe('GetFilenameFromUrl', () => {
     }
   ];
 
-  // for (const test of tests) {
-  //   it(`should process ${test.url} -> ${test.expected}`, () => {
-  //     testUrl(test);
-  //   });
-  // }
+  for (const test of tests) {
+    it(`should process ${test.url} -> ${test.expected}`, () => {
+      testUrl(test);
+    });
+  }
 
   if (process.platform === 'win32') {
     const test = {

--- a/test/tests/util.js
+++ b/test/tests/util.js
@@ -3,6 +3,8 @@
 const assert = require('assert');
 const { getFilenameFromUrl } = require('../../lib/util');
 
+const isWindows = process.platform === 'win32';
+
 function testUrl(options) {
   const url = getFilenameFromUrl(options.publicPath, options, options.url);
   console.log(url);
@@ -120,7 +122,8 @@ describe('GetFilenameFromUrl', () => {
       url: '/pathname%20with%20spaces.js',
       outputPath: '/',
       publicPath: '/',
-      expected: '/pathname with spaces.js'
+      // ref #284 - windows paths should persist %20
+      expected: isWindows ? '/pathname%20with%20spaces.js' : '/pathname with spaces.js'
     },
     {
       url: '/test/windows.txt',
@@ -277,12 +280,13 @@ describe('GetFilenameFromUrl', () => {
     });
   }
 
-  if (process.platform === 'win32') {
+  if (isWindows) {
+    // explicit test for #284
     const test = {
-      url: '\\foo.js',
-      outputPath: 'C:\\My%20Path\\wwwroot\\',
-      publicPath: '/',
-      expected: 'C:\\My%20Path\\wwwroot\\foo.js'
+      url: '/test/windows.txt',
+      outputPath: 'C:\\My%20Path\\wwwroot',
+      publicPath: '/test',
+      expected: 'C://\\My%20Path\\wwwroot/windows.txt'
     };
 
     it(`windows: should process ${test.url} -> ${test.expected}`, () => {

--- a/test/tests/util.js
+++ b/test/tests/util.js
@@ -9,7 +9,7 @@ function testUrl(options) {
 }
 
 describe('GetFilenameFromUrl', () => {
-  const tests = [
+  const tests = [ // eslint-disable-line
     {
       url: '/foo.js',
       outputPath: '/',

--- a/test/tests/util.js
+++ b/test/tests/util.js
@@ -7,7 +7,6 @@ const isWindows = process.platform === 'win32';
 
 function testUrl(options) {
   const url = getFilenameFromUrl(options.publicPath, options, options.url);
-  console.log(url);
   assert.equal(url, options.expected);
 }
 

--- a/test/tests/util.js
+++ b/test/tests/util.js
@@ -270,8 +270,21 @@ describe('GetFilenameFromUrl', () => {
     }
   ];
 
-  for (const test of tests) {
-    it(`should process ${test.url} -> ${test.expected}`, () => {
+  // for (const test of tests) {
+  //   it(`should process ${test.url} -> ${test.expected}`, () => {
+  //     testUrl(test);
+  //   });
+  // }
+
+  if (process.platform === 'win32') {
+    const test = {
+      url: 'C:\\My%20Path\\wwwroot\\foo.js',
+      outputPath: '/',
+      publicPath: '/',
+      expected: 'C:\\My%20Path\\wwwroot\\foo.js'
+    };
+
+    it(`windows: should process ${test.url} -> ${test.expected}`, () => {
       testUrl(test);
     });
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

Yes

**Summary**

fixes #284, on windows path spaces should resolve to %20

**Does this PR introduce a breaking change?**

For implementations relying on the bug, possibly.

**Other information**

This PR is WIP until this line is removed, as changes will be pushed to the target branch for AppVeyor to compile, as I don't have access to Windows at the moment. 
