### PR TITLE
Fix the exception thrown when `writeToDisk` is enabled in multi-compiler mode

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -10,54 +10,46 @@ const DevMiddlewareError = require('./DevMiddlewareError');
 
 const { mkdirp } = new NodeOutputFileSystem();
 
-function singleCompilerToDisk(singleCompiler, context) {
-  singleCompiler.hooks.afterEmit.tap('WebpackDevMiddleware', (compilation) => {
-    const { assets, compiler } = compilation;
-    const { log } = context;
-    const { writeToDisk: filter } = context.options;
-    let { outputPath } = compiler;
-
-    if (outputPath === '/') {
-      outputPath = compiler.context;
-    }
-
-    for (const assetPath of Object.keys(assets)) {
-      const asset = assets[assetPath];
-      const source = asset.source();
-      const isAbsolute = pathabs(assetPath);
-      const writePath = isAbsolute ? assetPath : path.join(outputPath, assetPath);
-      const relativePath = path.relative(process.cwd(), writePath);
-      const allowWrite = filter && typeof filter === 'function' ? filter(writePath) : true;
-
-      if (allowWrite) {
-        let output = source;
-
-        mkdirp.sync(path.dirname(writePath));
-
-        if (Array.isArray(source)) {
-          output = source.join('\n');
-        }
-
-        try {
-          fs.writeFileSync(writePath, output, 'utf-8');
-          log.debug(chalk`{cyan Asset written to disk}: ${relativePath}`);
-        } catch (e) {
-          log.error(`Unable to write asset to disk:\n${e}`);
-        }
-      }
-    }
-  });
-}
-
 module.exports = {
   toDisk(context) {
-    const { compiler } = context;
-    if (compiler.compilers) {
-      compiler.compilers.forEach((singleCompiler) => {
-        singleCompilerToDisk(singleCompiler, context);
+    const compilers = context.compiler.compilers || [context.compiler];
+    for (const compiler of compilers) {
+      compiler.hooks.afterEmit.tap('WebpackDevMiddleware', (compilation) => {
+        const { assets } = compilation;
+        const { log } = context;
+        const { writeToDisk: filter } = context.options;
+        let { outputPath } = compiler;
+
+        if (outputPath === '/') {
+          outputPath = compiler.context;
+        }
+
+        for (const assetPath of Object.keys(assets)) {
+          const asset = assets[assetPath];
+          const source = asset.source();
+          const isAbsolute = pathabs(assetPath);
+          const writePath = isAbsolute ? assetPath : path.join(outputPath, assetPath);
+          const relativePath = path.relative(process.cwd(), writePath);
+          const allowWrite = filter && typeof filter === 'function' ? filter(writePath) : true;
+
+          if (allowWrite) {
+            let output = source;
+
+            mkdirp.sync(path.dirname(writePath));
+
+            if (Array.isArray(source)) {
+              output = source.join('\n');
+            }
+
+            try {
+              fs.writeFileSync(writePath, output, 'utf-8');
+              log.debug(chalk`{cyan Asset written to disk}: ${relativePath}`);
+            } catch (e) {
+              log.error(`Unable to write asset to disk:\n${e}`);
+            }
+          }
+        }
       });
-    } else {
-      singleCompilerToDisk(compiler, context);
     }
   },
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -10,44 +10,55 @@ const DevMiddlewareError = require('./DevMiddlewareError');
 
 const { mkdirp } = new NodeOutputFileSystem();
 
-module.exports = {
-  toDisk(context) {
-    context.compiler.hooks.afterEmit.tap('WebpackDevMiddleware', (compilation) => {
-      const { assets, compiler } = compilation;
-      const { log } = context;
-      const { writeToDisk: filter } = context.options;
-      let { outputPath } = compiler;
+function singleCompilerToDisk(singleCompiler, context) {
+  singleCompiler.hooks.afterEmit.tap('WebpackDevMiddleware', (compilation) => {
+    const { assets, compiler } = compilation;
+    const { log } = context;
+    const { writeToDisk: filter } = context.options;
+    let { outputPath } = compiler;
 
-      if (outputPath === '/') {
-        outputPath = compiler.context;
-      }
+    if (outputPath === '/') {
+      outputPath = compiler.context;
+    }
 
-      for (const assetPath of Object.keys(assets)) {
-        const asset = assets[assetPath];
-        const source = asset.source();
-        const isAbsolute = pathabs(assetPath);
-        const writePath = isAbsolute ? assetPath : path.join(outputPath, assetPath);
-        const relativePath = path.relative(process.cwd(), writePath);
-        const allowWrite = filter && typeof filter === 'function' ? filter(writePath) : true;
+    for (const assetPath of Object.keys(assets)) {
+      const asset = assets[assetPath];
+      const source = asset.source();
+      const isAbsolute = pathabs(assetPath);
+      const writePath = isAbsolute ? assetPath : path.join(outputPath, assetPath);
+      const relativePath = path.relative(process.cwd(), writePath);
+      const allowWrite = filter && typeof filter === 'function' ? filter(writePath) : true;
 
-        if (allowWrite) {
-          let output = source;
+      if (allowWrite) {
+        let output = source;
 
-          mkdirp.sync(path.dirname(writePath));
+        mkdirp.sync(path.dirname(writePath));
 
-          if (Array.isArray(source)) {
-            output = source.join('\n');
-          }
+        if (Array.isArray(source)) {
+          output = source.join('\n');
+        }
 
-          try {
-            fs.writeFileSync(writePath, output, 'utf-8');
-            log.debug(chalk`{cyan Asset written to disk}: ${relativePath}`);
-          } catch (e) {
-            log.error(`Unable to write asset to disk:\n${e}`);
-          }
+        try {
+          fs.writeFileSync(writePath, output, 'utf-8');
+          log.debug(chalk`{cyan Asset written to disk}: ${relativePath}`);
+        } catch (e) {
+          log.error(`Unable to write asset to disk:\n${e}`);
         }
       }
-    });
+    }
+  });
+}
+
+module.exports = {
+  toDisk(context) {
+    const { compiler } = context;
+    if (compiler.compilers) {
+      compiler.compilers.forEach((singleCompiler) => {
+        singleCompilerToDisk(singleCompiler, context);
+      });
+    } else {
+      singleCompilerToDisk(compiler, context);
+    }
   },
 
   setFs(context, compiler) {

--- a/test/fixtures/server-test/webpack.array.config.js
+++ b/test/fixtures/server-test/webpack.array.config.js
@@ -1,12 +1,14 @@
 'use strict';
 
+const path = require('path');
+
 module.exports = [{
   mode: 'development',
   context: __dirname,
   entry: './foo.js',
   output: {
     filename: 'foo.js',
-    path: '/js1',
+    path: path.resolve(__dirname, 'js1'),
     publicPath: '/js1/'
   },
   module: {
@@ -24,7 +26,7 @@ module.exports = [{
   entry: './bar.js',
   output: {
     filename: 'bar.js',
-    path: '/js2',
+    path: path.resolve(__dirname, 'js2'),
     publicPath: '/js2/'
   }
 }];

--- a/test/tests/server.js
+++ b/test/tests/server.js
@@ -415,8 +415,8 @@ describe('Server', () => {
             fs.unlinkSync(bundlePathFoo);
           }
 
-          fs.rmdir(path.join(__dirname, '../fixtures/server-test/js1/'));
-          fs.rmdir(path.join(__dirname, '../fixtures/server-test/js2/'));
+          fs.rmdirSync(path.join(__dirname, '../fixtures/server-test/js1/'));
+          fs.rmdirSync(path.join(__dirname, '../fixtures/server-test/js2/'));
 
           done();
         });

--- a/test/tests/server.js
+++ b/test/tests/server.js
@@ -378,7 +378,7 @@ describe('Server', () => {
     });
   });
 
-  function writeToDiskWithMultiCompiler(value, done) {
+  function multiToDisk(value, done) {
     app = express();
     const compiler = webpack(webpackMultiConfig);
     instance = middleware(compiler, {
@@ -395,7 +395,7 @@ describe('Server', () => {
 
   describe('write to disk with MultiCompiler', () => {
     before((done) => {
-      writeToDiskWithMultiCompiler(true, done);
+      multiToDisk(true, done);
     });
     after(close);
 

--- a/test/tests/server.js
+++ b/test/tests/server.js
@@ -410,9 +410,9 @@ describe('Server', () => {
           ];
 
           for (const bundleFile of bundleFiles) {
-            const bundlePathFoo = path.join(__dirname, bundleFile);
-            assert(fs.existsSync(bundlePathFoo));
-            fs.unlinkSync(bundlePathFoo);
+            const bundlePath = path.join(__dirname, bundleFile);
+            assert(fs.existsSync(bundlePath));
+            fs.unlinkSync(bundlePath);
           }
 
           fs.rmdirSync(path.join(__dirname, '../fixtures/server-test/js1/'));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This is a bugfix 🐛🔫 for #290 😸. I'm running into the same problem these days.

**Did you add tests for your changes?**

Yes, I've added a test in `test/tests/server.js`

**Summary**

Fix the exception thrown when [`writeToDisk`](https://github.com/webpack/webpack-dev-middleware/pull/287) is enabled in multi-compiler mode.

**Does this PR introduce a breaking change?**

No.