### PR TITLE
Excluded outputPath from URI escaping to fix #297.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -89,24 +89,32 @@ module.exports = {
 
     let uri = outputPath;
 
-    if (filename) {
-      uri = urlJoin((outputPath || ''), filename);
-
-      if (!pathabs.posix(uri) && !pathabs.win32(uri)) {
-        uri = `/${uri}`;
-      }
-    }
-
-    // if no matches, use outputPath as filename
-    result = querystring.unescape(uri);
-
-    // fixes #284, on windows path spaces should resolve to %20
     /* istanbul ignore if */
     if (process.platform === 'win32') {
-      result = result.replace(/\s/g, '%20');
-    }
+      // Path Handling for Microsoft Windows
+      if (filename) {
+        uri = urlJoin((outputPath || ''), querystring.unescape(filename));
 
-    return result;
+        if (!pathabs.win32(uri)) {
+          uri = `/${uri}`;
+        }
+      }
+
+      return uri;
+    }
+    else {
+      // Path Handling for all other operating systems
+      if (filename) {
+        uri = urlJoin((outputPath || ''), filename);
+
+        if (!pathabs.posix(uri)) {
+          uri = `/${uri}`;
+        }
+      }
+
+      // if no matches, use outputPath as filename
+      return querystring.unescape(uri);
+    }
   },
 
   handleRangeHeaders(content, req, res) {

--- a/test/tests/util.js
+++ b/test/tests/util.js
@@ -121,8 +121,7 @@ describe('GetFilenameFromUrl', () => {
       url: '/pathname%20with%20spaces.js',
       outputPath: '/',
       publicPath: '/',
-      // ref #284 - windows paths should persist %20
-      expected: isWindows ? '/pathname%20with%20spaces.js' : '/pathname with spaces.js'
+      expected: '/pathname with spaces.js'
     },
     {
       url: '/test/windows.txt',
@@ -279,17 +278,48 @@ describe('GetFilenameFromUrl', () => {
     });
   }
 
+  // Explicit Tests for Microsoft Windows
   if (isWindows) {
-    // explicit test for #284
-    const test = {
-      url: '/test/windows.txt',
-      outputPath: 'C:\\My%20Path\\wwwroot',
-      publicPath: '/test',
-      expected: 'C://\\My%20Path\\wwwroot/windows.txt'
-    };
+    const windowsTests = [
+      // Tests for #284
+      {
+        url: '/test/windows.txt',
+        outputPath: 'C:\\My%20Path\\wwwroot',
+        publicPath: '/test',
+        expected: 'C://\\My%20Path\\wwwroot/windows.txt'
+      },
+      {
+        url: '/test/windows%202.txt',
+        outputPath: 'C:\\My%20Path\\wwwroot',
+        publicPath: '/test',
+        expected: 'C://\\My%20Path\\wwwroot/windows 2.txt'
+      },
+      // Tests for #297
+      {
+        url: '/test/windows.txt',
+        outputPath: 'C:\\My Path\\wwwroot',
+        publicPath: '/test',
+        expected: 'C://\\My Path\\wwwroot/windows.txt'
+      },
+      {
+        url: '/test/windows%202.txt',
+        outputPath: 'C:\\My Path\\wwwroot',
+        publicPath: '/test',
+        expected: 'C://\\My Path\\wwwroot/windows 2.txt'
+      },
+      // Tests for #284 & #297
+      {
+        url: '/windows%20test/test%20%26%20test%20%26%20%2520.txt',
+        outputPath: 'C:\\My %20 Path\\wwwroot',
+        publicPath: '/windows%20test',
+        expected: 'C://\\My %20 Path\\wwwroot/test & test & %20.txt'
+      }
+    ];
 
-    it(`windows: should process ${test.url} -> ${test.expected}`, () => {
-      testUrl(test);
-    });
+    for (const test of windowsTests) {
+      it(`windows: should process ${test.url} -> ${test.expected}`, () => {
+        testUrl(test);
+      });
+    }
   }
 });


### PR DESCRIPTION
This change fixes the regression tracked by #297 and introduced in https://github.com/webpack/webpack-dev-middleware/commit/08207ccf7759fdcea38566ea8848426c3f6c36bf.

To support both spaces in `outputPath` *and* URI-escape-like sequences such as `%20`, I have simply excluded `outputPath` from URI unescaping under Windows. The filename part is still unescaped.

Tests have been added - see changes for an illustration of what should now work. One test for #284 has been removed because it was invalid: %20, in a URI, should be resolved to space, always.