### PR TITLE
refactor(package): remove `path-is-absolute` dependency (`dependencies`)

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -3,7 +3,6 @@
 const fs = require('fs');
 const path = require('path');
 const MemoryFileSystem = require('memory-fs');
-const pathabs = require('path-is-absolute');
 const { colors } = require('webpack-log');
 const NodeOutputFileSystem = require('webpack/lib/node/NodeOutputFileSystem');
 const DevMiddlewareError = require('./DevMiddlewareError');
@@ -27,7 +26,7 @@ module.exports = {
         for (const assetPath of Object.keys(assets)) {
           const asset = assets[assetPath];
           const source = asset.source();
-          const isAbsolute = pathabs(assetPath);
+          const isAbsolute = path.isAbsolute(assetPath);
           const writePath = isAbsolute ? assetPath : path.join(outputPath, assetPath);
           const relativePath = path.relative(process.cwd(), writePath);
           const allowWrite = filter && typeof filter === 'function' ? filter(writePath) : true;
@@ -54,7 +53,7 @@ module.exports = {
   },
 
   setFs(context, compiler) {
-    if (typeof compiler.outputPath === 'string' && !pathabs.posix(compiler.outputPath) && !pathabs.win32(compiler.outputPath)) {
+    if (typeof compiler.outputPath === 'string' && !path.posix.isAbsolute(compiler.outputPath) && !path.win32.isAbsolute(compiler.outputPath)) {
       throw new DevMiddlewareError('`output.path` needs to be an absolute path or `/`.');
     }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,8 +1,8 @@
 'use strict';
 
+const path = require('path');
 const { parse } = require('url');
 const querystring = require('querystring');
-const pathabs = require('path-is-absolute');
 const parseRange = require('range-parser');
 const urlJoin = require('url-join');
 
@@ -94,7 +94,7 @@ module.exports = {
       if (filename) {
         uri = urlJoin((outputPath || ''), querystring.unescape(filename));
 
-        if (!pathabs.win32(uri)) {
+        if (!path.win32.isAbsolute(uri)) {
           uri = `/${uri}`;
         }
       }
@@ -106,7 +106,7 @@ module.exports = {
     if (filename) {
       uri = urlJoin((outputPath || ''), filename);
 
-      if (!pathabs.posix(uri)) {
+      if (!path.posix.isAbsolute(uri)) {
         uri = `/${uri}`;
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7234,7 +7234,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "loud-rejection": "^1.6.0",
     "memory-fs": "~0.4.1",
     "mime": "^2.3.1",
-    "path-is-absolute": "^1.0.0",
     "range-parser": "^1.0.3",
     "url-join": "^4.0.0",
     "webpack-log": "^2.0.0"


### PR DESCRIPTION
Removes the `path-is-absolute` dependency, since `path.isAbsolute` is natively supported on all `node` versions now

### Type

- [x] Refactor

### Issues

- None

### SemVer

- [x] Patch