### PR TITLE
feat(middleware): expose the memory filesystem to other middlewares (`response.locals.fs`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ In order to develop an app using server-side rendering, we need access to the
 generated with each build.
 
 With server-side rendering enabled, `webpack-dev-middleware` sets the `stat` to
-`res.locals.webpackStats` before invoking the next middleware, allowing a
+`res.locals.webpackStats` and the memory filesystem to `res.locals.fs` before invoking the next middleware, allowing a
 developer to render the page body and manage the response to clients.
 
 _Note: Requests for bundle files will still be handled by

--- a/README.md
+++ b/README.md
@@ -337,6 +337,8 @@ app.use(middleware(compiler, { serverSideRender: true }))
 // The following middleware would not be invoked until the latest build is finished.
 app.use((req, res) => {
   const assetsByChunkName = res.locals.webpackStats.toJson().assetsByChunkName
+  const fs = res.locals.fs
+  const outputPath = res.locals.webpackStats.toJson().outputPath
 
   // then use `assetsByChunkName` for server-sider rendering
   // For example, if you have only one main chunk:
@@ -344,10 +346,12 @@ app.use((req, res) => {
 <html>
   <head>
     <title>My App</title>
+    <style>
 		${normalizeAssets(assetsByChunkName.main)
 			  .filter(path => path.endsWith('.css'))
-			  .map(path => `<link rel="stylesheet" href="${path}" />`)
+			  .map(path => fs.readFileSync(outputPath + '/' + path))
 			  .join('\n')}
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -19,6 +19,7 @@ module.exports = function wrapper(context) {
       return new Promise(((resolve) => {
         ready(context, () => {
           res.locals.webpackStats = context.webpackStats;
+          res.locals.fs = context.fs;
           resolve(next());
         }, req);
       }));

--- a/test/tests/server.js
+++ b/test/tests/server.js
@@ -339,6 +339,7 @@ describe('Server', () => {
       request(app).get('/foo/bar')
         .expect(200, () => {
           assert(locals.webpackStats);
+          assert(locals.fs);
           done();
         });
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
feature

**Did you add tests for your changes?**
yes

**Summary**
In order for the next middleware in line to be able to use the memory FileSystem created by `webpack-dev-middleware` (and access the files generated in memory by the compilation process) this commit passes the context.fs to the res.locals along with webpackStats when ServerSideRender is set to true.

**Does this PR introduce a breaking change?**
No

**Other information**
This is a PR is contingent on ServerSideRender not being removed from the middleware