### PR TITLE
Only add charset to content-type header if defined in mime db

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -3,6 +3,7 @@
 const path = require('path');
 
 const mime = require('mime');
+const mimeDb = require('mime-db');
 
 const DevMiddlewareError = require('./DevMiddlewareError');
 const {
@@ -11,10 +12,6 @@ const {
   handleRequest,
   ready,
 } = require('./util');
-
-// Do not add a charset to the Content-Type header of these file types
-// otherwise the client will fail to render them correctly.
-const NonCharsetFileTypes = /\.(wasm|usdz)$/;
 
 module.exports = function wrapper(context) {
   return function middleware(req, res, next) {
@@ -97,14 +94,17 @@ module.exports = function wrapper(context) {
 
         content = handleRangeHeaders(content, req, res);
 
-        let contentType = mime.getType(filename) || '';
-
-        if (!NonCharsetFileTypes.test(filename)) {
-          contentType += '; charset=UTF-8';
-        }
-
         if (!res.getHeader('Content-Type')) {
-          res.setHeader('Content-Type', contentType);
+          const contentType = mime.getType(filename);
+          const mimeInfo = mimeDb[contentType];
+          const charset = mimeInfo && mimeInfo.charset;
+
+          if (contentType) {
+            res.setHeader(
+              'Content-Type',
+              contentType + (charset ? `; charset=${charset}` : '')
+            );
+          }
         }
 
         res.setHeader('Content-Length', content.length);

--- a/package-lock.json
+++ b/package-lock.json
@@ -6902,8 +6902,7 @@
     "mime-db": {
       "version": "1.38.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
-      "dev": true
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
     },
     "mime-types": {
       "version": "2.1.22",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   ],
   "dependencies": {
     "memory-fs": "^0.4.1",
-    "mime": "^2.3.1",
+    "mime": "^2.4.0",
+    "mime-db": "^1.38.0",
     "range-parser": "^1.0.3",
     "webpack-log": "^2.0.0"
   },

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -102,7 +102,7 @@ describe('Server', () => {
     it('request to image', (done) => {
       request(app)
         .get('/public/svg.svg')
-        .expect('Content-Type', 'image/svg+xml; charset=UTF-8')
+        .expect('Content-Type', 'image/svg+xml')
         .expect('Content-Length', '4778')
         .expect(200, done);
     });
@@ -124,7 +124,7 @@ describe('Server', () => {
     it('request to directory', (done) => {
       request(app)
         .get('/public/')
-        .expect('Content-Type', 'text/html; charset=UTF-8')
+        .expect('Content-Type', 'text/html')
         .expect('Content-Length', '10')
         .expect(200, /My Index\./, done);
     });
@@ -132,7 +132,7 @@ describe('Server', () => {
     it('request to subdirectory without trailing slash', (done) => {
       request(app)
         .get('/public/reference/mono-v6.x.x')
-        .expect('Content-Type', 'text/html; charset=UTF-8')
+        .expect('Content-Type', 'text/html')
         .expect('Content-Length', '9')
         .expect(200, /My Index\./, done);
     });
@@ -156,7 +156,6 @@ describe('Server', () => {
     it('request to non-public path', (done) => {
       request(app)
         .get('/nonpublic/')
-        .expect('Content-Type', 'text/html; charset=utf-8')
         .expect(404, done);
     });
   });
@@ -210,7 +209,6 @@ describe('Server', () => {
     it('request to directory', (done) => {
       request(app)
         .get('/')
-        .expect('Content-Type', 'text/html; charset=utf-8')
         .expect(404, done);
     });
   });
@@ -265,6 +263,10 @@ describe('Server', () => {
   describe('no extension support', () => {
     beforeAll((done) => {
       app = express();
+      app.use((req, res, next) => {
+        res.set('Content-Type', 'text/plain');
+        next();
+      });
       const compiler = webpack(webpackConfig);
       instance = middleware(compiler, {
         stats: 'errors-only',
@@ -281,7 +283,7 @@ describe('Server', () => {
       request(app)
         .get('/')
         .expect('hello')
-        .expect('Content-Type', '; charset=UTF-8')
+        .expect('Content-Type', 'text/plain; charset=utf-8')
         .expect(200, done);
     });
   });
@@ -333,7 +335,7 @@ describe('Server', () => {
       request(app)
         .get('/')
         .expect('welcome')
-        .expect('Content-Type', /text\/html/)
+        .expect('Content-Type', 'text/html')
         .expect(200, done);
     });
   });
@@ -361,7 +363,7 @@ describe('Server', () => {
       request(app)
         .get('/')
         .expect('welcome')
-        .expect('Content-Type', /text\/html/)
+        .expect('Content-Type', 'text/html')
         .expect(200, done);
     });
   });


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix/functionality change

**Did you add tests for your changes?**
Yes

**Summary**
Closes #350 
`charset=utf-8` was being appended to the content-type header of every mime type regardless if it required it (#136).  This PR uses mime-db to look up the charset for each mime type and add it appropriately.

**Does this PR introduce a breaking change?**
Don't think so unless someone was relying on the previously incorrect behavior.

**Other information**
- I removed Content-Type tests from things that expect a 404. Not sure how/what was setting it.