### PR TITLE
fix: use mkdirp package instead of implicit webpack dependency

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2,12 +2,10 @@
 
 const fs = require('fs');
 const path = require('path');
+const mkdirp = require('mkdirp');
 const MemoryFileSystem = require('memory-fs');
 const { colors } = require('webpack-log');
-const NodeOutputFileSystem = require('webpack/lib/node/NodeOutputFileSystem');
 const DevMiddlewareError = require('./DevMiddlewareError');
-
-const { mkdirp } = new NodeOutputFileSystem();
 
 module.exports = {
   toDisk(context) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4611,8 +4611,7 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -4667,7 +4666,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "memory-fs": "~0.4.1",
     "mime": "^2.3.1",
+    "mkdirp": "~0.5.0",
     "range-parser": "^1.0.3",
     "webpack-log": "^2.0.0"
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

no (but no observable changes, and tests pass)

**Summary**

I'm working on perhaps a somewhat exotic usage of this plugin. I noticed, when getting "module not found" errors, that it implicitly depends on `webpack` core, but only for one function (mkdirp) which simply [delegated](https://github.com/webpack/webpack/blob/master/lib/node/NodeOutputFileSystem.js#L13_ to the `mkdirp`. Pull that in directly here.

**Does this PR introduce a breaking change?**

No

**Other information**
