### PR TITLE
fix(middleware): do not add 'null' to Content-Type

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -69,7 +69,7 @@ module.exports = function wrapper(context) {
         let content = context.fs.readFileSync(filename);
         content = handleRangeHeaders(content, req, res);
 
-        let contentType = mime.getType(filename);
+        let contentType = mime.getType(filename) || '';
 
         // do not add charset to WebAssembly files, otherwise compileStreaming will fail in the client
         if (!/\.wasm$/.test(filename)) {

--- a/test/tests/server.js
+++ b/test/tests/server.js
@@ -219,6 +219,29 @@ describe('Server', () => {
     });
   });
 
+  describe('no extension support', () => {
+    before((done) => {
+      app = express();
+      const compiler = webpack(webpackConfig);
+      instance = middleware(compiler, {
+        stats: 'errors-only',
+        logLevel,
+        index: 'noextension'
+      });
+      app.use(instance);
+      listen = listenShorthand(done);
+      instance.fileSystem.writeFileSync('/noextension', 'hello');
+    });
+    after(close);
+
+    it('request to noextension', (done) => {
+      request(app).get('/')
+        .expect('hello')
+        .expect('Content-Type', '; charset=UTF-8')
+        .expect(200, done);
+    });
+  });
+
   describe('custom mimeTypes', () => {
     before((done) => {
       app = express();


### PR DESCRIPTION
fixes: #354

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

Of course!

**Summary**

Do not pass 'null' as media-type when mime-type lookup fails.

See #354 

**Does this PR introduce a breaking change?**

No