### PR TITLE
fix(fs): fix inconsistency from main compiler

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -36,7 +36,9 @@ module.exports = {
 
             mkdirp.sync(path.dirname(writePath));
 
-            if (Array.isArray(source)) {
+            if (!Buffer.isBuffer(source)) {
+              output = Buffer.from(source, 'utf8');
+            } else if (Array.isArray(source)) {
               output = source.join('\n');
             }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

I'm looking forward to adding them, but I might need some help/an advice from maintainers.

**Summary**

Main webpack compiler transforms sources to `Buffer` before storing them
to disk. While it might seem innocuous to skip this step and call
`fs.writeFile` directly, not calling `Buffer.from(..., 'utf8')` breaks
serialization of `.wasm` files. Web assembly asset's `.source()` method
returns `ArrayBuffer` instance, and would be written as
`[object ArrayBuffer]` if `Buffer.from()` is absent.

See: https://github.com/webpack/webpack/blob/217b2ad7e2c4fa09715a05eaf4b2969a4c67e29d/lib/Compiler.js#L336-L338
See: https://github.com/zeit/next.js/issues/5995

**Does this PR introduce a breaking change?**

No

**Other information**
