### PR TITLE
Don't add charset to certain file types

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -5,6 +5,10 @@ const mime = require('mime');
 const DevMiddlewareError = require('./DevMiddlewareError');
 const { getFilenameFromUrl, handleRangeHeaders, handleRequest, ready } = require('./util');
 
+// Do not add a charset to the Content-Type header of these file types
+// otherwise the client will fail to render them correctly.
+const NonCharsetFileTypes = /\.(wasm|usdz)$/;
+
 module.exports = function wrapper(context) {
   return function middleware(req, res, next) {
     // fixes #282. credit @cexoso. in certain edge situations res.locals is
@@ -71,8 +75,7 @@ module.exports = function wrapper(context) {
 
         let contentType = mime.getType(filename) || '';
 
-        // do not add charset to WebAssembly files, otherwise compileStreaming will fail in the client
-        if (!/\.wasm$/.test(filename)) {
+        if (!NonCharsetFileTypes.test(filename)) {
           contentType += '; charset=UTF-8';
         }
 

--- a/test/tests/server.js
+++ b/test/tests/server.js
@@ -295,17 +295,21 @@ describe('Server', () => {
     });
   });
 
-  describe('WebAssembly', () => {
+  describe('Special file type headers', () => {
     before((done) => {
       app = express();
       const compiler = webpack(webpackConfig);
       instance = middleware(compiler, {
         stats: 'errors-only',
-        logLevel
+        logLevel,
+        mimeTypes: {
+          'model/vnd.pixar.usd': ['usdz']
+        }
       });
       app.use(instance);
       listen = listenShorthand(done);
       instance.fileSystem.writeFileSync('/hello.wasm', 'welcome');
+      instance.fileSystem.writeFileSync('/3dAr.usdz', '010101');
     });
     after(close);
 
@@ -313,6 +317,13 @@ describe('Server', () => {
       request(app).get('/hello.wasm')
         .expect('Content-Type', 'application/wasm')
         .expect('welcome')
+        .expect(200, done);
+    });
+
+    it('request to 3dAr.usdz', (done) => {
+      request(app).get('/3dAr.usdz')
+        .expect('Content-Type', 'model/vnd.pixar.usd')
+        .expect('010101')
         .expect(200, done);
     });
   });


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix. #350
Less aggressive alternative to PR #351 

**Did you add tests for your changes?**
Yes

**Summary**
Creates a variable to special case more file types that should not automatically have a charset added to their content-type header.  This was already the case for wasm and this also adds usdz.

**Does this PR introduce a breaking change?**
No

**Other information**
I originally attempted to look up each filetype in mime-db (#351) to determine if it should receive a charset.  However, that only looks up if the file type has a "default" charset defined by the spec which is not necessarily good for friendly out-of-the box support and could have introduced breaking changes.