### PR TITLE
fix(middleware): do not trigger multiple concurrent rebuilds in lazy mode

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -149,7 +149,7 @@ module.exports = {
 
   handleRequest(context, filename, processRequest, req) {
     // in lazy mode, rebuild on bundle request
-    if (context.options.lazy && (!context.options.filename || context.options.filename.test(filename))) {
+    if (context.options.lazy && !context.compiler.running && (!context.options.filename || context.options.filename.test(filename))) {
       context.rebuild();
     }
 

--- a/test/tests/lazy.js
+++ b/test/tests/lazy.js
@@ -34,7 +34,8 @@ describe('Lazy mode', () => {
       invalid: hook('invalid'),
       run: hook('run'),
       watchRun: hook('watchRun')
-    }
+    },
+    running: false
   };
 
   beforeEach(() => {
@@ -45,6 +46,7 @@ describe('Lazy mode', () => {
 
   afterEach(() => {
     sandbox.restore();
+    compiler.running = false;
   });
 
   describe('builds', () => {
@@ -90,6 +92,17 @@ describe('Lazy mode', () => {
 
         done();
       }, 1000);
+    });
+
+    it('should not trigger a second compilation if the compiler is already running', (done) => {
+      compiler.running = true;
+      instance(req, res, next);
+      assert.equal(compiler.run.callCount, 0);
+      hooks.done(doneStats);
+      setTimeout(() => {
+        assert.equal(next.callCount, 1);
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

Yes

**Summary**

Addresses https://github.com/webpack/webpack-dev-middleware/issues/359

**Does this PR introduce a breaking change?**

I don't think so

**Other information**

It may be that the watchoptions config means that this isn't necessary, in which case feel free to reject :)