### PR TITLE
Remove querystring from filenames when writing to disk

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -26,8 +26,9 @@ module.exports = {
         for (const assetPath of Object.keys(assets)) {
           const asset = assets[assetPath];
           const source = asset.source();
-          const isAbsolute = path.isAbsolute(assetPath);
-          const writePath = isAbsolute ? assetPath : path.join(outputPath, assetPath);
+          const [assetPathClean] = assetPath.split('?');
+          const isAbsolute = path.isAbsolute(assetPathClean);
+          const writePath = isAbsolute ? assetPathClean : path.join(outputPath, assetPathClean);
           const relativePath = path.relative(process.cwd(), writePath);
           const allowWrite = filter && typeof filter === 'function' ? filter(writePath) : true;
 

--- a/test/fixtures/server-test/webpack.querystring.config.js
+++ b/test/fixtures/server-test/webpack.querystring.config.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = {
+  mode: 'development',
+  context: __dirname,
+  entry: './foo.js',
+  output: {
+    filename: 'bundle.js?[contenthash]',
+    path: '/'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(svg|html)$/,
+        loader: 'file-loader',
+        query: { name: '[name].[ext]' }
+      }
+    ]
+  }
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This is a bug fix to bring file writing behavior closer to that of webpack and the WriteFilePlugin.

**Did you add tests for your changes?**

Yes

**Summary**

Webpack and the WriteFilePlugin cut off filenames at the first ?, so you can use filenames like `'[name].js?[contenthash]'` without writing hashes to your filesystem. This updates the dev middleware to do the same when `writeToDisk` is enabled.

**Does this PR introduce a breaking change?**

If you were using writeToDisk with a ? in `output.filename` then you won't end up with a ? in filenames on disk any more. If you pass a filter function to `writeToDisk` then that function will also stop getting the querystring.

**Other information**

Here's where querystrings get cut off in webpack and the writefileplugin:
https://github.com/webpack/webpack/blob/v4.28.4/lib/Compiler.js#L321
https://github.com/gajus/write-file-webpack-plugin/blob/v4.4.0/src/WriteFileWebpackPlugin.js#L174