### PR TITLE
Add tests to assert if subdirectories with special characters are served correctly

### DIFF
--- a/test/tests/server.js
+++ b/test/tests/server.js
@@ -53,11 +53,11 @@ describe('Server', () => {
       instance.fileSystem.writeFileSync('/123a123412.hot-update.json', '["hi"]');
 
       // Add a nested directory and index.html inside
-      instance.fileSystem.mkdirSync("/reference");
-      instance.fileSystem.mkdirSync("/reference/mono-v6.x.x");
+      instance.fileSystem.mkdirSync('/reference');
+      instance.fileSystem.mkdirSync('/reference/mono-v6.x.x');
       instance.fileSystem.writeFileSync(
-        "/reference/mono-v6.x.x/index.html",
-        "My Index."
+        '/reference/mono-v6.x.x/index.html',
+        'My Index.'
       );
     });
 
@@ -111,9 +111,9 @@ describe('Server', () => {
         .expect(200, /My Index\./, done);
     });
 
-    it("request to subdirectory without trailing slash", done => {
+    it('request to subdirectory without trailing slash', (done) => {
       request(app)
-        .get("/public/reference/mono-v6.x.x")
+        .get('/public/reference/mono-v6.x.x')
         .expect('Content-Type', 'text/html; charset=UTF-8')
         .expect('Content-Length', '9')
         .expect(200, /My Index\./, done);

--- a/test/tests/server.js
+++ b/test/tests/server.js
@@ -51,6 +51,14 @@ describe('Server', () => {
       listen = listenShorthand(done);
       // Hack to add a mock HMR json file to the in-memory filesystem.
       instance.fileSystem.writeFileSync('/123a123412.hot-update.json', '["hi"]');
+
+      // Add a nested directory and index.html inside
+      instance.fileSystem.mkdirSync("/reference");
+      instance.fileSystem.mkdirSync("/reference/mono-v6.x.x");
+      instance.fileSystem.writeFileSync(
+        "/reference/mono-v6.x.x/index.html",
+        "My Index."
+      );
     });
 
     after(close);
@@ -100,6 +108,14 @@ describe('Server', () => {
       request(app).get('/public/')
         .expect('Content-Type', 'text/html; charset=UTF-8')
         .expect('Content-Length', '10')
+        .expect(200, /My Index\./, done);
+    });
+
+    it("request to subdirectory without trailing slash", done => {
+      request(app)
+        .get("/public/reference/mono-v6.x.x")
+        .expect('Content-Type', 'text/html; charset=UTF-8')
+        .expect('Content-Length', '9')
         .expect(200, /My Index\./, done);
     });
 

--- a/test/tests/util.js
+++ b/test/tests/util.js
@@ -274,7 +274,7 @@ describe('GetFilenameFromUrl', () => {
       outputPath: '/',
       publicPath: '/',
       expected: '/folder-name-with-dots/mono-v6.x.x'
-    },
+    }
   ];
 
   for (const test of tests) {

--- a/test/tests/util.js
+++ b/test/tests/util.js
@@ -268,7 +268,13 @@ describe('GetFilenameFromUrl', () => {
       outputPath: '/test/#leadinghash',
       publicPath: '/',
       expected: '/test/#leadinghash/test/sample.txt'
-    }
+    },
+    {
+      url: '/folder-name-with-dots/mono-v6.x.x',
+      outputPath: '/',
+      publicPath: '/',
+      expected: '/folder-name-with-dots/mono-v6.x.x'
+    },
   ];
 
   for (const test of tests) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Adds some tests

**Did you add tests for your changes?**

Yes

**Summary**

Gatsby uses `webpack-dev-middleware` and I wrote these tests while trying to debug https://github.com/gatsbyjs/gatsby/issues/11348 so I figured I might as well contribute back

Please feel free to reject if this edge case is too specific 

**Does this PR introduce a breaking change?**

No

**Other information**
