### PR TITLE
use memfs instead of memory-fs

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2,10 +2,10 @@
 
 const fs = require('fs');
 const path = require('path');
-const { fs: memfs } = require('memfs');
-// borrow join and normalize from memory-fs
-memfs.join = require('memory-fs/lib/join');
-memfs.normalize = require('memory-fs/lib/normalize');
+const { Volume } = require('memfs');
+// TODO: move these two functions to a better place
+const memoryFsJoin = require('memory-fs/lib/join');
+const memoryFsNormalize = require('memory-fs/lib/normalize');
 const { colors } = require('webpack-log');
 const NodeOutputFileSystem = require('webpack/lib/node/NodeOutputFileSystem');
 const DevMiddlewareError = require('./DevMiddlewareError');
@@ -63,12 +63,14 @@ module.exports = {
 
     let fileSystem;
     // store our files in memory
-    const isMemoryFs = !compiler.compilers && compiler.outputFileSystem === memfs;
+    const isMemoryFs = !compiler.compilers && compiler.outputFileSystem instanceof Volume;
 
     if (isMemoryFs) {
       fileSystem = compiler.outputFileSystem;
     } else {
-      fileSystem = memfs;
+      fileSystem = new Volume();
+      fileSystem.join = memoryFsJoin;
+      fileSystem.normalize = memoryFsNormalize;
       compiler.outputFileSystem = fileSystem;
     }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2,7 +2,10 @@
 
 const fs = require('fs');
 const path = require('path');
-const MemoryFileSystem = require('memory-fs');
+const { fs: memfs } = require('memfs');
+// borrow join and normalize from memory-fs
+memfs.join = require('memory-fs/lib/join');
+memfs.normalize = require('memory-fs/lib/normalize');
 const { colors } = require('webpack-log');
 const NodeOutputFileSystem = require('webpack/lib/node/NodeOutputFileSystem');
 const DevMiddlewareError = require('./DevMiddlewareError');
@@ -60,12 +63,12 @@ module.exports = {
 
     let fileSystem;
     // store our files in memory
-    const isMemoryFs = !compiler.compilers && compiler.outputFileSystem instanceof MemoryFileSystem;
+    const isMemoryFs = !compiler.compilers && compiler.outputFileSystem === memfs;
 
     if (isMemoryFs) {
       fileSystem = compiler.outputFileSystem;
     } else {
-      fileSystem = new MemoryFileSystem();
+      fileSystem = memfs;
       compiler.outputFileSystem = fileSystem;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2543,6 +2543,11 @@
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
+    "fast-extend": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/fast-extend/-/fast-extend-0.0.2.tgz",
+      "integrity": "sha1-9exCz0C5Rg9SGmOH37Ut7u1nHb0="
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -2820,6 +2825,11 @@
       "requires": {
         "minipass": "^2.2.1"
       }
+    },
+    "fs-monkey": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-0.3.3.tgz",
+      "integrity": "sha512-FNUvuTAJ3CqCQb5ELn+qCbGR/Zllhf2HtwsdAtBi59s1WeCjKMT81fHcSu7dwIskqGVK+MmOrb7VOBlq3/SItw=="
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
@@ -3995,6 +4005,15 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
+      }
+    },
+    "memfs": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-2.15.0.tgz",
+      "integrity": "sha512-vktLqfHB1K4I9oiWlG4VjbztEreU5LqgnTnlVimr4bKNhJwjTmKg5+eYIimmNiKVUolTUrWSy2k/KEyqqLqZrQ==",
+      "requires": {
+        "fast-extend": "0.0.2",
+        "fs-monkey": "^0.3.3"
       }
     },
     "memory-fs": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "release": "standard-version"
   },
   "dependencies": {
+    "memfs": "^2.15.0",
     "memory-fs": "~0.4.1",
     "mime": "^2.3.1",
     "range-parser": "^1.0.3",

--- a/test/tests/server.js
+++ b/test/tests/server.js
@@ -390,7 +390,7 @@ describe('Server', () => {
     });
 
     it('request to non-public path', (done) => {
-      request(app).get('/nonpublic/').expect(404, done);
+      request(app).get('/').expect(404, done);
     });
   });
 

--- a/test/tests/server.js
+++ b/test/tests/server.js
@@ -390,7 +390,7 @@ describe('Server', () => {
     });
 
     it('request to non-public path', (done) => {
-      request(app).get('/').expect(404, done);
+      request(app).get('/nonpublic/').expect(404, done);
     });
   });
 


### PR DESCRIPTION
Uses [`memfs`](https://www.npmjs.com/package/memfs) instead of `memory-fs` for the in-memory `outputFileSystem`. `memfs` appears to be actively maintained, while `memory-fs` hasn't had any meaningful updates in a few years.

This allows people to use out-of-the-box webpack-dev-server for novel use-cases where having a fully API-compliant filesystem would be beneficial. Related: https://github.com/webpack/memory-fs/issues/43

I ran into issues adding my own server-side-rendering middleware into webpack-dev-server that needed to `require` files from the `outputFileSystem`. Doing this with memory-fs was difficult, time consuming and seemed not to work very reliably. My alternative was to write to disk, which means 30 second re-builds.

Interestingly, `memfs` is part of a suite of tools that enables useful stuff like [patching `require` to import modules from an in-memory file system](https://github.com/streamich/fs-monkey/blob/master/docs/api/patchRequire.md).

This was a simple drop-in replacement.

- [x] swap memory-fs with memfs
- [ ] move the `join` and `normalize` methods from memory-fs to "a better place"
- [x] All tests pass