### PR TITLE
Configurable file system via options.fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ app.use(middleware(compiler, {
 app.listen(3000, () => console.log('Example app listening on port 3000!'))
 ```
 
+
 ## Options
 
 The middleware accepts an `options` Object. The following is a property reference
@@ -210,7 +211,7 @@ please see the [webpack documentation](https://webpack.js.org/configuration/watc
 Type: `Boolean|Function`  
 Default: `false`
 
-If true, the option will instruct the module to write files to the configured
+If `true`, the option will instruct the module to write files to the configured
 location on disk as specified in your `webpack` config file. _Setting
 `writeToDisk: true` won't change the behavior of the `webpack-dev-middleware`,
 and bundle files accessed through the browser will still be served from memory._
@@ -230,6 +231,14 @@ of `true` _will_ write the file to disk. eg.
   }
 }
 ```
+
+### fs
+Type: `Object`  
+Default: `MemoryFileSystem`
+
+Set the default file system which will be used by webpack as primary destination of generated files. Default is set to webpack's default file system: [memory-fs](https://github.com/webpack/memory-fs). This option isn't affected by the [writeToDisk](#writeToDisk) option.
+
+**Note:** As of 3.5.x version of the middleware you have to provide `.join()` method to the `fs` instance. This can be done simply by using `path.join`.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ app.use(middleware(compiler, {
 app.listen(3000, () => console.log('Example app listening on port 3000!'))
 ```
 
-
 ## Options
 
 The middleware accepts an `options` Object. The following is a property reference
@@ -238,7 +237,10 @@ Default: `MemoryFileSystem`
 
 Set the default file system which will be used by webpack as primary destination of generated files. Default is set to webpack's default file system: [memory-fs](https://github.com/webpack/memory-fs). This option isn't affected by the [writeToDisk](#writeToDisk) option.
 
-**Note:** As of 3.5.x version of the middleware you have to provide `.join()` method to the `fs` instance. This can be done simply by using `path.join`.
+**Note:** As of 3.5.x version of the middleware you have to provide `.join()` method to the `fs` instance manually. This can be done simply by using `path.join`:
+```js
+  fs.join = path.join // no need to bind
+```
 
 ## API
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -60,9 +60,21 @@ module.exports = {
 
     let fileSystem;
     // store our files in memory
-    const isMemoryFs = !compiler.compilers && compiler.outputFileSystem instanceof MemoryFileSystem;
+    const isConfiguredFs = context.options.fs;
+    const isMemoryFs = !isConfiguredFs
+      && !compiler.compilers
+      && compiler.outputFileSystem instanceof MemoryFileSystem;
 
-    if (isMemoryFs) {
+    if (isConfiguredFs) {
+      const { fs } = context.options;
+      if (typeof fs.join !== 'function') {
+        // very shallow check
+        throw new Error('Invalid options: options.fs.join() method is expected');
+      }
+
+      compiler.outputFileSystem = fs;
+      fileSystem = fs;
+    } else if (isMemoryFs) {
       fileSystem = compiler.outputFileSystem;
     } else {
       fileSystem = new MemoryFileSystem();

--- a/test/tests/file-system.js
+++ b/test/tests/file-system.js
@@ -48,17 +48,14 @@ describe('FileSystem', () => {
 
     const fs = { join() {} };
 
-    it('should provide .join()', (done) => {
-      try {
-        middleware(compiler, { fs });
-      } catch (error) {
-        done(error);
-        return;
-      }
+    it('should throw on invalid fs', (done) => {
+      assert.throws(() => {
+        middleware(compiler, { fs: {} });
+      });
       done();
     });
 
-    it('should be assigned to the compiler.outputFileSystem', (done) => {
+    it('should assign fs to the compiler.outputFileSystem', (done) => {
       const instance = middleware(compiler, { fs });
 
       assert.equal(compiler.outputFileSystem, fs);

--- a/test/tests/file-system.js
+++ b/test/tests/file-system.js
@@ -37,6 +37,43 @@ describe('FileSystem', () => {
     assert.equal(firstFs, secondFs);
   });
 
+  describe('options.fs', () => {
+    // lightweight compiler mock
+    const hook = { tap() {} };
+    const compiler = {
+      outputPath: '/output',
+      watch() {},
+      hooks: { done: hook, invalid: hook, run: hook, watchRun: hook }
+    };
+
+    const fs = { join() {} };
+
+    it('should provide .join()', (done) => {
+      try {
+        middleware(compiler, { fs });
+      } catch (error) {
+        done(error);
+        return;
+      }
+      done();
+    });
+
+    it('should be assigned to the compiler.outputFileSystem', (done) => {
+      const instance = middleware(compiler, { fs });
+
+      assert.equal(compiler.outputFileSystem, fs);
+      instance.close(done);
+    });
+    it('should go safely when compiler.outputFileSystem is assigned by fs externally', (done) => {
+      const cmplr = Object.create(compiler);
+      cmplr.outputFileSystem = fs;
+      const instance = middleware(cmplr, { fs });
+
+      assert.equal(cmplr.outputFileSystem, fs);
+      instance.close(done);
+    });
+  });
+
   it('should throw on invalid outputPath config', () => {
     const compiler = fakeWebpack();
     compiler.outputPath = './dist';

--- a/test/tests/file-system.js
+++ b/test/tests/file-system.js
@@ -61,6 +61,7 @@ describe('FileSystem', () => {
       assert.equal(compiler.outputFileSystem, fs);
       instance.close(done);
     });
+
     it('should go safely when compiler.outputFileSystem is assigned by fs externally', (done) => {
       const cmplr = Object.create(compiler);
       cmplr.outputFileSystem = fs;


### PR DESCRIPTION
**What kind of change does this PR introduce?**
* fs option which can be used to configure non-default file system
(it is forced to use `memory-fs` instead currently)

**What are use cases?**
* The same as for middleware, but with opportunity to use other memory file systems (like [memfs](https://github.com/streamich/memfs))

**Did you add tests for your changes?**
* adds couple of tests

<!-- Note that we won't merge your changes if you don't add tests. -->

**Summary**
* Solves longstanding problem of not having opportunity to use other non-memory-fs libraries and configure it manually either via `webpackCompiler.outputFileSystem` or `middleware(..., ..., { fs: fileSystem }`

**Does this PR introduce a breaking change?**
* Negative