### PR TITLE
strip query string params from targetPath

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -9,6 +9,8 @@ const DevMiddlewareError = require('./DevMiddlewareError');
 
 const { mkdirp } = new NodeOutputFileSystem();
 
+const stripQueryString = input => input.split('?')[0]
+
 module.exports = {
   toDisk(context) {
     const compilers = context.compiler.compilers || [context.compiler];
@@ -32,7 +34,12 @@ module.exports = {
             targetFile = targetFile.substr(0, queryStringIdx);
           }
 
-          const targetPath = path.isAbsolute(targetFile) ? targetFile : path.join(outputPath, targetFile);
+          const targetPath = stripQueryString(
+            path.isAbsolute(targetFile)
+              ? targetFile
+              : path.join(outputPath, targetFile)
+          );
+
           const allowWrite = filter && typeof filter === 'function' ? filter(targetPath) : true;
 
           if (allowWrite) {


### PR DESCRIPTION
Strip query string from targetPath, since some assets have paths in the form of [name].[ext]?[hash]. See https://github.com/zeit/next.js/issues/6481.
