### PR TITLE
Do not overwrite Content-Type

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -79,7 +79,9 @@ module.exports = function wrapper(context) {
           contentType += '; charset=UTF-8';
         }
 
-        res.setHeader('Content-Type', contentType);
+        if (!res.getHeader('Content-Type')) {
+          res.setHeader('Content-Type', contentType);
+        }
         res.setHeader('Content-Length', content.length);
 
         const { headers } = context.options;

--- a/test/tests/server.js
+++ b/test/tests/server.js
@@ -259,6 +259,27 @@ describe('Server', () => {
     });
   });
 
+  describe('custom Content-Type', () => {
+    before((done) => {
+      app = express();
+      const compiler = webpack(webpackConfig);
+      instance = middleware(compiler, {
+        stats: 'errors-only',
+        logLevel,
+        headers: { 'Content-Type': 'application/octet-stream' }
+      });
+      app.use(instance);
+      listen = listenShorthand(done);
+    });
+    after(close);
+
+    it('Do not guess mime type if Content-Type header is found ', (done) => {
+      request(app).get('/bundle.js')
+        .expect('Content-Type', 'application/octet-stream')
+        .expect(200, done);
+    });
+  });
+
   describe('custom mimeTypes', () => {
     before((done) => {
       app = express();


### PR DESCRIPTION
**What kind of change does this PR introduce?**

When the Content-Type header is already present (for example it has been 
set by other middleware) we do not overwrite it.

**Did you add tests for your changes?**

Yes, added unit test to the suite.

**Summary**

Closes #376

**Does this PR introduce a breaking change?**

No

**Other information**
