### PR TITLE
Fix overwrite Content-Type test

### DIFF
--- a/test/tests/server.js
+++ b/test/tests/server.js
@@ -262,18 +262,21 @@ describe('Server', () => {
   describe('custom Content-Type', () => {
     before((done) => {
       app = express();
+      app.use((req, res, next) => {
+        res.set('Content-Type', 'application/octet-stream');
+        next();
+      });
       const compiler = webpack(webpackConfig);
       instance = middleware(compiler, {
         stats: 'errors-only',
-        logLevel,
-        headers: { 'Content-Type': 'application/octet-stream' }
+        logLevel
       });
       app.use(instance);
       listen = listenShorthand(done);
     });
     after(close);
 
-    it('Do not guess mime type if Content-Type header is found ', (done) => {
+    it('Do not guess mime type if Content-Type header is found', (done) => {
       request(app).get('/bundle.js')
         .expect('Content-Type', 'application/octet-stream')
         .expect(200, done);


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bugfix for https://github.com/webpack/webpack-dev-middleware/pull/377#issuecomment-470170219

**Did you add tests for your changes?**

Yes, in test suite.

**Summary**

The headers get set *after* Content-Type already got overwritten. Hence 
the test is not testing whether the Content-Type overwrite is actually 
skipped.

**Does this PR introduce a breaking change?**

No

**Other information**
