### PR TITLE
Let ExpressJS handle Content-Length header

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -82,7 +82,8 @@ module.exports = function wrapper(context) {
         if (!res.getHeader('Content-Type')) {
           res.setHeader('Content-Type', contentType);
         }
-        res.setHeader('Content-Length', content.length);
+        // The Content-Length header is set by ExpressJS appropriately. See
+        // https://github.com/expressjs/express/blob/master/lib/response.js#L178-L195
 
         const { headers } = context.options;
         if (headers) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Remove obsolete code.

**Did you add tests for your changes?**

No, existing tests cover the change.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Setting the `Content-Length` header from within `webpack-dev-middleware` 
does not have any effect as it is overwriten later by ExpressJS in 
https://github.com/expressjs/express/blob/master/lib/response.js#L178-L195
Remove the obsolete code.

Closes #379 

**Does this PR introduce a breaking change?**

No.

**Other information**
