### PR TITLE
Add check for res.getHeader

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -79,7 +79,7 @@ module.exports = function wrapper(context) {
           contentType += '; charset=UTF-8';
         }
 
-        if (!res.getHeader('Content-Type')) {
+        if (res.getHeader && !res.getHeader('Content-Type')) {
           res.setHeader('Content-Type', contentType);
         }
         res.setHeader('Content-Length', content.length);


### PR DESCRIPTION
Adding this check to prevent `UnhandledPromiseRejectionWarning: TypeError: res.getHeader is not a function`

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

No - this is a simple null/undefined check.

**Summary**

I began working on a project and noticed that my application was not working as usual. When I checked the logs I saw the following error and stack trace:

```
[WBPACK] (node:56090) UnhandledPromiseRejectionWarning: TypeError: res.getHeader is not a function
[WBPACK]     at processRequest (/Users/iwhite/Code/Homeaway/react-email-components/node_modules/webpack-dev-middleware/lib/middleware.js:82:18)
[WBPACK]     at ready (/Users/iwhite/Code/Homeaway/react-email-components/node_modules/webpack-dev-middleware/lib/util.js:51:12)
[WBPACK]     at handleRequest (/Users/iwhite/Code/Homeaway/react-email-components/node_modules/webpack-dev-middleware/lib/util.js:167:5)
[WBPACK]     at Promise (/Users/iwhite/Code/Homeaway/react-email-components/node_modules/webpack-dev-middleware/lib/middleware.js:44:7)
[WBPACK]     at new Promise (<anonymous>)
[WBPACK]     at middleware (/Users/iwhite/Code/Homeaway/react-email-components/node_modules/webpack-dev-middleware/lib/middleware.js:43:12)
[WBPACK]     at Promise.all.Promise (/Users/iwhite/Code/Homeaway/react-email-components/node_modules/webpack-serve/node_modules/koa-webpack/index.js:43:7)
[WBPACK]     at new Promise (<anonymous>)
[WBPACK]     at /Users/iwhite/Code/Homeaway/react-email-components/node_modules/webpack-serve/node_modules/koa-webpack/index.js:42:5
[WBPACK]     at dispatch (/Users/iwhite/Code/Homeaway/react-email-components/node_modules/koa-compose/index.js:44:32)
[WBPACK] (node:56090) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
[WBPACK] (node:56090) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
[WBPACK] (node:56090) UnhandledPromiseRejectionWarning: TypeError: res.getHeader is not a function
[WBPACK]     at processRequest (/Users/iwhite/Code/Homeaway/react-email-components/node_modules/webpack-dev-middleware/lib/middleware.js:82:18)
[WBPACK]     at ready (/Users/iwhite/Code/Homeaway/react-email-components/node_modules/webpack-dev-middleware/lib/util.js:51:12)
[WBPACK]     at handleRequest (/Users/iwhite/Code/Homeaway/react-email-components/node_modules/webpack-dev-middleware/lib/util.js:167:5)
[WBPACK]     at Promise (/Users/iwhite/Code/Homeaway/react-email-components/node_modules/webpack-dev-middleware/lib/middleware.js:44:7)
[WBPACK]     at new Promise (<anonymous>)
[WBPACK]     at middleware (/Users/iwhite/Code/Homeaway/react-email-components/node_modules/webpack-dev-middleware/lib/middleware.js:43:12)
[WBPACK]     at Promise.all.Promise (/Users/iwhite/Code/Homeaway/react-email-components/node_modules/webpack-serve/node_modules/koa-webpack/index.js:43:7)
[WBPACK]     at new Promise (<anonymous>)
[WBPACK]     at /Users/iwhite/Code/Homeaway/react-email-components/node_modules/webpack-serve/node_modules/koa-webpack/index.js:42:5
[WBPACK]     at dispatch (/Users/iwhite/Code/Homeaway/react-email-components/node_modules/koa-compose/index.js:44:32)
[WBPACK] (node:56090) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
```

Here are the specific lines from the stack trace in the screenshot:
```
[WBPACK] (node:56090) UnhandledPromiseRejectionWarning: TypeError: res.getHeader is not a function
[WBPACK]     at processRequest (/Users/iwhite/Code/Homeaway/react-email-components/node_modules/webpack-dev-middleware/lib/middleware.js:82:18)
```

It appears an unguarded call to `res.getHeader()` was added in [this PR.](https://github.com/webpack/webpack-dev-middleware/commit/b2a6fed#diff-d7dfcb350720309421bbb465055aafdfR82)

When I added a simple null/undefined check for the `getHeader` method I was able to run my code without error.

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
OS: macOS 10.12.6
node version: v10.14.1
npm version: 6.7.0
webpack-dev-middleware version: 3.6.1
webpack version: 4.29.6
