### PR TITLE
fix: check existence of `res.getHeader`

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -79,7 +79,7 @@ module.exports = function wrapper(context) {
           contentType += '; charset=UTF-8';
         }
 
-        if (!res.getHeader('Content-Type')) {
+        if (res.getHeader && !res.getHeader('Content-Type')) {
           res.setHeader('Content-Type', contentType);
         }
         res.setHeader('Content-Length', content.length);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bug fix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No tests needed.

<!-- Note that we won't merge your changes if you don't add tests. -->

**Summary**

This PR is tagged "bug fix" but actually a feature request.

I'm the maintainer of [VuePress](https://github.com/vuejs/vuepress) and recently we found a very influential issue([vuepress dev: throws res.getHeader() is not a function](https://github.com/vuejs/vuepress/issues/1417)) and we cannot fix it by ourself. and it's introduced by https://github.com/webpack/webpack-dev-middleware/commit/b2a6fedce908bd348054b6fbb6e81fe638ef9744. (But after careful investigation, I found that this is the legacy of history.)

This is due to VuePress@0.x depends on `webpack-serve@1.0.2`, `webpack-serve` depends on `koa-webpack`, and `koa-webpack` doesn't lock the version of `webpack-dev-middleware`:

https://github.com/shellscape/koa-webpack/blob/0ea07dbd11f899f0e419808f2472b2d832d0d9c3/package.json#L24

```json
"webpack-dev-middleware": "^3.0.0",
```

The issue is already fixed in shellscape/koa-webpack#110 (released as v5.2.2) but we cannot enjoy this fix since `webpack-serve@1.0.2` depends on `koa-webpack@4.x`.

One way to resolve the issue is to update `webpack-serve` dependency to 2.x.
However, `webpack-serve` introduced breaking changes in v2 and we‘re not going to make any technological changes for VuePress@0.x because it's stable enough and we're also focused on 1.x.

Since `webpack-server` is no longer maintained, the best way I can think of is to check the existence of `res.getHeader` at `webpack-dev-middleware`. Of course, all of this is because in `koa-webpack@4.x`, the author at that time did not pass in the `getHeader` method:

https://github.com/shellscape/koa-webpack/blob/v4.0.0/index.js#L48

```js
  return (context, next) => Promise.all([
    waitMiddleware(),
    new Promise((resolve) => {
      dev(context.req, {
        end: (content) => {
          context.body = content; // eslint-disable-line no-param-reassign
          resolve();
        },
        setHeader: context.set.bind(context),
        locals: context.state
      }, () => resolve(next()));
    })
  ]);
```

I'll appreciate you if you accept this change, Thanks!


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
