### PR TITLE
fix(middleware): add HEAD method support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ _Note: The `publicPath` property is required, whereas all other options are opti
 ### methods
 
 Type: `Array`  
-Default: `[ 'GET' ,'HEAD']`
+Default: `undefined`
 
 This property allows a user to pass the list of HTTP request methods accepted by the server.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ _Note: The `publicPath` property is required, whereas all other options are opti
 Type: `Array`  
 Default: `undefined`
 
-This property allows a user to pass the list of HTTP request methods accepted by the server.
+This property allows a user to set HTTP request methods accepted by the server.
+
+By default all HTTP request methods are accepted by the server.
 
 ### headers
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ _Note: The `publicPath` property is required, whereas all other options are opti
 ### methods
 
 Type: `Array`  
-Default: `[ 'GET' ]`
+Default: `[ 'GET' ,'HEAD']`
 
 This property allows a user to pass the list of HTTP request methods accepted by the server.
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -44,7 +44,7 @@ module.exports = function wrapper(context) {
       });
     }
 
-    const acceptedMethods = context.options.methods || ['GET'];
+    const acceptedMethods = context.options.methods || ['GET', 'HEAD'];
 
     if (acceptedMethods.indexOf(req.method) === -1) {
       return goNext();

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -44,9 +44,9 @@ module.exports = function wrapper(context) {
       });
     }
 
-    const acceptedMethods = context.options.methods || ['GET', 'HEAD'];
+    const acceptedMethods = context.options.methods;
 
-    if (acceptedMethods.indexOf(req.method) === -1) {
+    if (acceptedMethods && acceptedMethods.indexOf(req.method) === -1) {
       return goNext();
     }
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -106,7 +106,9 @@ describe('Server', () => {
     it('POST request to bundle file', (done) => {
       request(app)
         .post('/public/bundle.js')
-        .expect(404, done);
+        .expect('Content-Type', 'application/javascript; charset=UTF-8')
+        .expect('Content-Length', '4631')
+        .expect(200, /console\.log\('Hey\.'\)/, done);
     });
 
     it('request to image', (done) => {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -86,6 +86,14 @@ describe('Server', () => {
         });
     });
 
+    it('HEAD request to bundle file', (done) => {
+      request(app)
+        .head('/public/bundle.js')
+        .expect('Content-Type', 'application/javascript; charset=UTF-8')
+        .expect('Content-Length', '4631')
+        .expect(200, /console\.log\('Hey\.'\)/, done);
+    });
+
     it('GET request to bundle file', (done) => {
       request(app)
         .get('/public/bundle.js')
@@ -185,6 +193,12 @@ describe('Server', () => {
         // TODO(michael-ciniawsky) investigate the need for this test
         .expect('Content-Length', '4631')
         .expect(200, /console\.log\('Hey\.'\)/, done);
+    });
+
+    it("HEAD request to bundle file with methods set to ['POST']", (done) => {
+      request(app)
+        .get('/public/bundle.js')
+        .expect(404, done);
     });
 
     it("GET request to bundle file with methods set to ['POST']", (done) => {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -91,7 +91,7 @@ describe('Server', () => {
         .head('/public/bundle.js')
         .expect('Content-Type', 'application/javascript; charset=UTF-8')
         .expect('Content-Length', '4631')
-        .expect(200, /console\.log\('Hey\.'\)/, done);
+        .expect(200, undefined, done);
     });
 
     it('GET request to bundle file', (done) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests. -->

**Summary**
fixes: https://github.com/webpack/webpack-dev-server/issues/1833
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
when I run tests I get lint errors : 
`Expected linebreaks to be 'LF' but found 'CRLF'` and  `Delete '␍'`
and when I disable lint and run tests only requests' tests fail in expecting `Content-Length` and `Content-Range`
I'm using windows and I tried this on Ubuntu and it's the same. so is it normal?