### PR TITLE
fix: directly used mkdirp instead of through Webpack

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -4,12 +4,10 @@ const fs = require('fs');
 const path = require('path');
 
 const MemoryFileSystem = require('memory-fs');
+const mkdirp = require('mkdirp');
 const { colors } = require('webpack-log');
-const NodeOutputFileSystem = require('webpack/lib/node/NodeOutputFileSystem');
 
 const DevMiddlewareError = require('./DevMiddlewareError');
-
-const { mkdirp } = new NodeOutputFileSystem();
 
 module.exports = {
   toDisk(context) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8539,8 +8539,7 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -8609,7 +8608,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "memory-fs": "^0.4.1",
     "mime": "^2.4.2",
+    "mkdirp": "^0.5.1",
     "range-parser": "^1.2.1",
     "webpack-log": "^2.0.0"
   },


### PR DESCRIPTION
Fixes Webpack 5 usage by no longer requiring the removed webpack/lib/node/NodeOutputFileSystem

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Fixes #435.

### Breaking Changes

Introduces dependency on `mkdirp`, which was only transient through `webpack` before.
