### PR TITLE
Refactor fs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,16 +96,6 @@ export default function wdm(compiler, opts = defaults) {
       }
     },
 
-    context,
-
-    fileSystem: context.fs,
-
-    getFilenameFromUrl: getFilenameFromUrl.bind(
-      this,
-      context.options.publicPath,
-      context.compiler
-    ),
-
     invalidate(callback) {
       // eslint-disable-next-line no-param-reassign
       callback = callback || noop;
@@ -124,5 +114,13 @@ export default function wdm(compiler, opts = defaults) {
 
       ready(context, callback, {});
     },
+
+    context,
+
+    getFilenameFromUrl: getFilenameFromUrl.bind(
+      this,
+      context.options.publicPath,
+      context.compiler
+    ),
   });
 }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -30,9 +30,10 @@ export default function wrapper(context) {
           context,
           () => {
             // eslint-disable-next-line no-param-reassign
-            res.locals.webpackStats = context.webpackStats;
-            // eslint-disable-next-line no-param-reassign
-            res.locals.fs = context.fs;
+            res.locals.webpack = {
+              stats: context.webpackStats,
+              outputFileSystem: context.outputFileSystem,
+            };
 
             resolve(next());
           },
@@ -61,7 +62,7 @@ export default function wrapper(context) {
       // eslint-disable-next-line consistent-return
       function processRequest() {
         try {
-          let stat = context.fs.statSync(filename);
+          let stat = context.outputFileSystem.statSync(filename);
 
           if (!stat.isFile()) {
             if (stat.isDirectory()) {
@@ -75,7 +76,7 @@ export default function wrapper(context) {
               }
 
               filename = path.posix.join(filename, index);
-              stat = context.fs.statSync(filename);
+              stat = context.outputFileSystem.statSync(filename);
 
               if (!stat.isFile()) {
                 throw new DevMiddlewareError('next');
@@ -89,7 +90,7 @@ export default function wrapper(context) {
         }
 
         // server content
-        let content = context.fs.readFileSync(filename);
+        let content = context.outputFileSystem.readFileSync(filename);
 
         content = handleRangeHeaders(content, req, res);
 
@@ -137,7 +138,7 @@ export default function wrapper(context) {
 
       if (HASH_REGEXP.test(filename)) {
         try {
-          if (context.fs.statSync(filename).isFile()) {
+          if (context.outputFileSystem.statSync(filename).isFile()) {
             processRequest();
 
             return;

--- a/src/utils/setupOutputFileSystem.js
+++ b/src/utils/setupOutputFileSystem.js
@@ -46,7 +46,7 @@ export default function setupOutputFileSystem(compiler, context) {
   }
 
   // eslint-disable-next-line no-param-reassign
-  context.fs = fileSystem;
+  context.outputFileSystem = fileSystem;
 }
 
 module.exports = setupOutputFileSystem;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -59,15 +59,15 @@ describe('Server', () => {
       app.use(instance);
       listen = listenShorthand(done);
       // Hack to add a mock HMR json file to the in-memory filesystem.
-      instance.fileSystem.writeFileSync(
+      instance.context.outputFileSystem.writeFileSync(
         '/123a123412.hot-update.json',
         '["hi"]'
       );
 
       // Add a nested directory and index.html inside
-      instance.fileSystem.mkdirSync('/reference');
-      instance.fileSystem.mkdirSync('/reference/mono-v6.x.x');
-      instance.fileSystem.writeFileSync(
+      instance.context.outputFileSystem.mkdirSync('/reference');
+      instance.context.outputFileSystem.mkdirSync('/reference/mono-v6.x.x');
+      instance.context.outputFileSystem.writeFileSync(
         '/reference/mono-v6.x.x/index.html',
         'My Index.'
       );
@@ -292,7 +292,7 @@ describe('Server', () => {
       });
       app.use(instance);
       listen = listenShorthand(done);
-      instance.fileSystem.writeFileSync('/noextension', 'hello');
+      instance.context.outputFileSystem.writeFileSync('/noextension', 'hello');
     });
     afterAll(close);
 
@@ -380,7 +380,10 @@ describe('Server', () => {
       });
       app.use(instance);
       listen = listenShorthand(done);
-      instance.fileSystem.writeFileSync('/Index.phtml', 'welcome');
+      instance.context.outputFileSystem.writeFileSync(
+        '/Index.phtml',
+        'welcome'
+      );
     });
     afterAll(close);
 
@@ -414,7 +417,10 @@ describe('Server', () => {
       });
       app.use(instance);
       listen = listenShorthand(done);
-      instance.fileSystem.writeFileSync('/Index.phtml', 'welcome');
+      instance.context.outputFileSystem.writeFileSync(
+        '/Index.phtml',
+        'welcome'
+      );
     });
     afterAll(close);
 
@@ -449,8 +455,8 @@ describe('Server', () => {
       });
       app.use(instance);
       listen = listenShorthand(done);
-      instance.fileSystem.writeFileSync('/hello.wasm', 'welcome');
-      instance.fileSystem.writeFileSync('/3dAr.usdz', '010101');
+      instance.context.outputFileSystem.writeFileSync('/hello.wasm', 'welcome');
+      instance.context.outputFileSystem.writeFileSync('/3dAr.usdz', '010101');
     });
     afterAll(close);
 
@@ -551,8 +557,8 @@ describe('Server', () => {
       request(app)
         .get('/foo/bar')
         .expect(200, () => {
-          expect(locals.webpackStats).toBeDefined();
-          expect(locals.fs).toBeDefined();
+          expect(locals.webpack.stats).toBeDefined();
+          expect(locals.webpack.outputFileSystem).toBeDefined();
 
           done();
         });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Better API and use name as used in webpack, improve locals access because other middlewares can setup `fs` too and it is break app, better use this under `webpack` property

### Breaking Changes

Yes

- the `fs` option was renamed to the `outputFileSystem` option. 
- the `fileSystem` property was removed from API, please use `context.outputFileSystem` instead. 
- the middleware `locals` now under `res.locals.webpack` - use `res.locals.webpack.stats` for access stats and `res.locals.webpack.outputFileSystem` for access `outputFileSystem`.

### Additional Info

No