### PR TITLE
Refactor rename webpack stats to stats

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ export default function wdm(compiler, opts = defaults) {
 
   const context = {
     state: false,
-    webpackStats: null,
+    stats: null,
     callbacks: [],
     options,
     compiler,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -31,7 +31,7 @@ export default function wrapper(context) {
           () => {
             // eslint-disable-next-line no-param-reassign
             res.locals.webpack = {
-              stats: context.webpackStats,
+              stats: context.stats,
               outputFileSystem: context.outputFileSystem,
             };
 

--- a/src/utils/ready.js
+++ b/src/utils/ready.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line consistent-return
 export default function ready(context, fn, req) {
   if (context.state) {
-    return fn(context.webpackStats);
+    return fn(context.stats);
   }
 
   context.log.info(`wait until bundle finished: ${req.url || fn.name}`);

--- a/src/utils/setupHooks.js
+++ b/src/utils/setupHooks.js
@@ -23,7 +23,7 @@ export default function setupHooks(context) {
     // eslint-disable-next-line no-param-reassign
     context.state = true;
     // eslint-disable-next-line no-param-reassign
-    context.webpackStats = stats;
+    context.stats = stats;
 
     // Do the stuff in nextTick, because bundle may be invalidated
     // if a change happened while compiling


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Rename `webpackStats` to `stats` because `webpack` prefix is unnecessary

### Breaking Changes

Yes

### Additional Info

I will write tests after https://github.com/webpack/webpack-dev-middleware/pull/494, also we don't have tests on this right now