### PR TITLE
refactor: resolve todo

### DIFF
--- a/src/utils/setupWriteToDisk.js
+++ b/src/utils/setupWriteToDisk.js
@@ -30,11 +30,6 @@ export default function setupWriteToDisk(context) {
 
             let { outputPath } = compiler;
 
-            // TODO Why? Need remove in future major release
-            if (outputPath === '/') {
-              outputPath = compiler.context;
-            }
-
             outputPath = compilation.getPath(outputPath, {});
             content = info;
             targetPath = path.join(outputPath, targetFile);


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

resolve todo

### Breaking Changes

No

### Additional Info

It is invalid logic, we should respect `output.path` as is