### PR TITLE
Fix output file system in multi compiler mode

### DIFF
--- a/src/utils/setupOutputFileSystem.js
+++ b/src/utils/setupOutputFileSystem.js
@@ -30,8 +30,13 @@ export default function setupOutputFileSystem(context) {
     outputFileSystem.join = path.join.bind(path);
   }
 
-  // eslint-disable-next-line no-param-reassign
-  context.compiler.outputFileSystem = outputFileSystem;
+  const compilers = context.compiler.compilers || [context.compiler];
+
+  for (const compiler of compilers) {
+    // eslint-disable-next-line no-param-reassign
+    compiler.outputFileSystem = outputFileSystem;
+  }
+
   // eslint-disable-next-line no-param-reassign
   context.outputFileSystem = outputFileSystem;
 }


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The `outputFileSystem` option doesn't work in multi-compiler mode.

### Breaking Changes

No

### Additional Info

No