### PR TITLE
fix: handle exceptions for reading files

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -9,7 +9,7 @@ import ready from './utils/ready';
 
 // Do not add a charset to the Content-Type header of these file types
 // otherwise the client will fail to render them correctly.
-const NonCharsetFileTypes = /\.(wasm|usdz)$/;
+const nonCharsetFileTypes = /\.(wasm|usdz)$/;
 
 const HASH_REGEXP = /[0-9a-f]{10,}/;
 
@@ -81,18 +81,24 @@ export default function wrapper(context) {
               throw new DevMiddlewareError('next');
             }
           }
-        } catch (e) {
+        } catch (_ignoreError) {
           return resolve(goNext());
         }
 
         // server content
-        let content = context.outputFileSystem.readFileSync(filename);
+        let content;
+
+        try {
+          content = context.outputFileSystem.readFileSync(filename);
+        } catch (_ignoreError) {
+          return resolve(goNext());
+        }
 
         content = handleRangeHeaders(content, req, res);
 
         let contentType = mime.getType(filename) || '';
 
-        if (!NonCharsetFileTypes.test(filename)) {
+        if (!nonCharsetFileTypes.test(filename)) {
           contentType += '; charset=UTF-8';
         }
 
@@ -122,7 +128,7 @@ export default function wrapper(context) {
 
             return;
           }
-        } catch (_error) {
+        } catch (_ignoreError) {
           // Ignore error
         }
       }

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -96,6 +96,13 @@ describe('middleware', () => {
           path.resolve(compiler.outputPath, '3dAr.usdz'),
           '010101'
         );
+        instance.context.outputFileSystem.writeFileSync(
+          path.resolve(
+            compiler.outputPath,
+            'throw-an-exception-on-readFileSync.txt'
+          ),
+          'exception'
+        );
       });
 
       afterAll((done) => {
@@ -246,6 +253,22 @@ describe('middleware', () => {
           .expect('Content-Type', 'model/vnd.pixar.usd')
           .expect('010101')
           .expect(200, fileData.toString(), done);
+      });
+
+      it('request to deleted file', (done) => {
+        const spy = jest
+          .spyOn(instance.context.outputFileSystem, 'readFileSync')
+          .mockImplementation(() => {
+            throw new Error('error');
+          });
+
+        request(app)
+          .get('/public/throw-an-exception-on-readFileSync.txt')
+          .expect(404, () => {
+            spy.mockRestore();
+
+            done();
+          });
       });
     });
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Some exceptions still can be throw in `readFileSync`, it is hard to implement in tested environment, but I just use `spy` to reproduce

### Breaking Changes

No

### Additional Info

No