### PR TITLE
Refactor migrate on mime types

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,18 +94,12 @@ Default: `undefined`
 ### mimeTypes
 
 Type: `Object`  
-Default: `null`
+Default: `undefined`
 
 This property allows a user to register custom mime types or extension mappings.
-eg. `mimeTypes: { 'text/html': [ 'phtml' ] }`.
+eg. `mimeTypes: { phtml: 'text/html' }`.
 
-By default node-mime will throw an error if you try to map a type to an extension
-that is already assigned to another type. Passing `force: true` will suppress this behavior
-(overriding any previous mapping).
-eg. `mimeTypes: { typeMap: { 'text/html': [ 'phtml' ] }, force: true }`.
-
-Please see the documentation for
-[`node-mime`](https://github.com/broofa/node-mime#mimedefinetypemap-force--false) for more information.
+Please see the documentation for [`mime-types`](https://github.com/jshttp/mime-types) for more information.
 
 ### publicPath
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10325,22 +10325,15 @@
         "brorand": "^1.0.1"
       }
     },
-    "mime": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
-    },
     "mime-db": {
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
-      "dev": true
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
     },
     "mime-types": {
       "version": "2.1.26",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
       "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
-      "dev": true,
       "requires": {
         "mime-db": "1.43.0"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "memfs": "^3.0.4",
-    "mime": "^2.4.4",
+    "mime-types": "^2.1.26",
     "range-parser": "^1.2.1",
     "schema-utils": "^2.6.4"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import validateOptions from 'schema-utils';
+import mime from 'mime-types';
 
 import middleware from './middleware';
 import setupHooks from './utils/setupHooks';
@@ -27,6 +28,14 @@ export default function wdm(compiler, opts = defaults) {
     compiler,
     watching: null,
   };
+
+  const { mimeTypes } = options;
+
+  if (mimeTypes) {
+    const { types } = mime;
+
+    mime.types = { ...mimeTypes, ...types };
+  }
 
   setupHooks(context);
   setupLogger(context);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import mime from 'mime';
 import validateOptions from 'schema-utils';
 
 import middleware from './middleware';
@@ -20,15 +19,6 @@ export default function wdm(compiler, opts = defaults) {
   validateOptions(schema, opts, 'webpack Dev Middleware');
 
   const options = Object.assign({}, defaults, opts);
-
-  // defining custom MIME type
-  if (options.mimeTypes) {
-    const typeMap = options.mimeTypes.typeMap || options.mimeTypes;
-    const force = Boolean(options.mimeTypes.force);
-
-    mime.define(typeMap, force);
-  }
-
   const context = {
     state: false,
     stats: null,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,15 +1,11 @@
 import path from 'path';
 
-import mime from 'mime';
+import mime from 'mime-types';
 
 import DevMiddlewareError from './DevMiddlewareError';
 import getFilenameFromUrl from './utils/getFilenameFromUrl';
 import handleRangeHeaders from './utils/handleRangeHeaders';
 import ready from './utils/ready';
-
-// Do not add a charset to the Content-Type header of these file types
-// otherwise the client will fail to render them correctly.
-const nonCharsetFileTypes = /\.(wasm|usdz)$/;
 
 const HASH_REGEXP = /[0-9a-f]{10,}/;
 
@@ -96,14 +92,10 @@ export default function wrapper(context) {
 
         content = handleRangeHeaders(content, req, res);
 
-        let contentType = mime.getType(filename) || '';
+        if (!res.get('Content-Type')) {
+          const contentType = mime.contentType(path.extname(filename));
 
-        if (contentType) {
-          if (!nonCharsetFileTypes.test(filename)) {
-            contentType += '; charset=utf-8';
-          }
-
-          if (!res.get('Content-Type')) {
+          if (contentType) {
             res.set('Content-Type', contentType);
           }
         }

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -401,7 +401,7 @@ describe('middleware', () => {
     });
   });
 
-  describe.skip('mimeTypes option', () => {
+  describe('mimeTypes option', () => {
     describe('custom extensions', () => {
       beforeAll((done) => {
         const compiler = getCompiler(webpackConfig);
@@ -410,45 +410,7 @@ describe('middleware', () => {
           stats: 'errors-only',
           index: 'Index.phtml',
           mimeTypes: {
-            'text/html': ['phtml'],
-          },
-        });
-
-        app = express();
-        app.use(instance);
-
-        listen = listenShorthand(done);
-
-        instance.context.outputFileSystem.mkdirSync(compiler.outputPath, {
-          recursive: true,
-        });
-        instance.context.outputFileSystem.writeFileSync(
-          path.resolve(compiler.outputPath, 'Index.phtml'),
-          'welcome'
-        );
-      });
-
-      afterAll(close);
-
-      it('request to Index.phtml', (done) => {
-        request(app)
-          .get('/')
-          .expect('welcome')
-          .expect('Content-Type', /text\/html/)
-          .expect(200, done);
-      });
-    });
-
-    describe('force option for overriding any previous mapping', () => {
-      beforeAll((done) => {
-        const compiler = getCompiler(webpackConfig);
-
-        instance = middleware(compiler, {
-          stats: 'errors-only',
-          index: 'Index.phtml',
-          mimeTypes: {
-            typeMap: { 'text/html': ['phtml'] },
-            force: true,
+            phtml: 'text/html',
           },
         });
 
@@ -1359,7 +1321,7 @@ describe('middleware', () => {
       });
     });
 
-    describe.skip('with "string" value with custom extension and defined custom MIME type', () => {
+    describe('with "string" value with custom extension and defined custom MIME type', () => {
       beforeAll((done) => {
         const compiler = getCompiler(webpackConfig);
 
@@ -1367,7 +1329,7 @@ describe('middleware', () => {
           stats: 'errors-only',
           index: 'index.custom',
           mimeTypes: {
-            'text/html': ['custom'],
+            custom: 'text/html',
           },
           publicPath: '/',
         });

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -56,12 +56,6 @@ describe('middleware', () => {
         instance = middleware(compiler, {
           stats: 'errors-only',
           publicPath: '/public/',
-          mimeTypes: {
-            typeMap: {
-              'model/vnd.pixar.usd': ['usdz'],
-            },
-            force: true,
-          },
         });
 
         app = express();
@@ -164,7 +158,7 @@ describe('middleware', () => {
         request(app)
           .get('/public/svg.svg')
           .expect('Content-Length', contentLength)
-          .expect('Content-Type', 'image/svg+xml; charset=utf-8')
+          .expect('Content-Type', 'image/svg+xml')
           .expect(200, done);
       });
 
@@ -254,7 +248,7 @@ describe('middleware', () => {
         request(app)
           .get('/public/3dAr.usdz')
           .expect('Content-Length', contentLength)
-          .expect('Content-Type', 'model/vnd.pixar.usd')
+          .expect('Content-Type', 'model/vnd.usdz+zip')
           .expect('010101')
           .expect(200, fileData.toString(), done);
       });
@@ -407,7 +401,7 @@ describe('middleware', () => {
     });
   });
 
-  describe('mimeTypes option', () => {
+  describe.skip('mimeTypes option', () => {
     describe('custom extensions', () => {
       beforeAll((done) => {
         const compiler = getCompiler(webpackConfig);
@@ -1298,6 +1292,74 @@ describe('middleware', () => {
     });
 
     describe('with "string" value', () => {
+      beforeAll((done) => {
+        const compiler = getCompiler(webpackConfig);
+
+        instance = middleware(compiler, {
+          stats: 'errors-only',
+          index: 'default.html',
+          publicPath: '/',
+        });
+
+        app = express();
+        app.use(instance);
+
+        listen = listenShorthand(done);
+
+        instance.context.outputFileSystem.mkdirSync(compiler.outputPath, {
+          recursive: true,
+        });
+        instance.context.outputFileSystem.writeFileSync(
+          path.resolve(compiler.outputPath, 'default.html'),
+          'hello'
+        );
+      });
+
+      afterAll(close);
+
+      it('request to directory', (done) => {
+        request(app)
+          .get('/')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(200, done);
+      });
+    });
+
+    describe('with "string" value with custom extension', () => {
+      beforeAll((done) => {
+        const compiler = getCompiler(webpackConfig);
+
+        instance = middleware(compiler, {
+          stats: 'errors-only',
+          index: 'index.custom',
+          publicPath: '/',
+        });
+
+        app = express();
+        app.use(instance);
+
+        listen = listenShorthand(done);
+
+        instance.context.outputFileSystem.mkdirSync(compiler.outputPath, {
+          recursive: true,
+        });
+        instance.context.outputFileSystem.writeFileSync(
+          path.resolve(compiler.outputPath, 'index.custom'),
+          'hello'
+        );
+      });
+
+      afterAll(close);
+
+      it('request to directory', (done) => {
+        request(app)
+          .get('/')
+          .expect('Content-Type', 'application/octet-stream')
+          .expect(200, done);
+      });
+    });
+
+    describe.skip('with "string" value with custom extension and defined custom MIME type', () => {
       beforeAll((done) => {
         const compiler = getCompiler(webpackConfig);
 

--- a/test/validation-options.test.js
+++ b/test/validation-options.test.js
@@ -5,10 +5,7 @@ import getCompiler from './helpers/getCompiler';
 describe('validation', () => {
   const cases = {
     mimeTypes: {
-      success: [
-        { 'text/html': ['phtml'] },
-        { typeMap: { 'text/html': ['phtml'] }, force: true },
-      ],
+      success: [{ phtml: ['text/html'] }],
       failure: ['foo'],
     },
     stats: {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

fixes #350

### Breaking Changes

Yes

### Additional Info

- Do not add `utf-8` to requests with custom MIME types
- Do not add `utf-8` to requests which can be non `utf-8`
- The `mimeTypes` option was changed - no the `force` option, you need specify `extension` and `type`
- migrate on `mime-types` because `mime` is deprecated
- refactor tests