### PR TITLE
Refactor get filename from url

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,6 @@ Some of the benefits of using this middleware include:
   has completed.
 - Supports hot module reload (HMR).
 
-## Requirements
-
-This module requires a minimum of Node v6.9.0 and Webpack v4.0.0, and must be used with a
-server that accepts express-style middleware.
-
 ## Getting Started
 
 First thing's first, install the module:
@@ -62,10 +57,7 @@ app.listen(3000, () => console.log('Example app listening on port 3000!'));
 
 ## Options
 
-The middleware accepts an `options` Object. The following is a property reference
-for the Object.
-
-_Note: The `publicPath` property is required, whereas all other options are optional_
+The middleware accepts an `options` Object. The following is a property reference for the Object.
 
 ### methods
 
@@ -103,13 +95,12 @@ Please see the documentation for [`mime-types`](https://github.com/jshttp/mime-t
 
 ### publicPath
 
-Type: `String`  
-_Required_
+Type: `String`
+Default: `output.publicPath`
 
-The public path that the middleware is bound to. _Best Practice: use the same
-`publicPath` defined in your webpack config. For more information about
-`publicPath`, please see
-[the webpack documentation](https://webpack.js.org/guides/public-path)._
+The public path that the middleware is bound to.
+_Best Practice: use the same `publicPath` defined in your webpack config.
+For more information about `publicPath`, please see [the webpack documentation](https://webpack.js.org/guides/public-path)._
 
 ### serverSideRender
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
     "lint:js": "eslint --cache src test",
     "lint": "npm-run-all -l -p \"lint:**\"",
+    "prepare": "npm run build",
     "build": "del dist && babel src -d dist",
     "release": "standard-version",
     "security": "npm audit",
@@ -24,8 +25,7 @@
     "test:coverage": "npm run test:only -- --collectCoverageFrom=\"src/**/*.js\" --coverage",
     "pretest": "npm run lint",
     "test": "npm run test:coverage",
-    "defaults": "webpack-defaults",
-    "prepublish": "npm run build"
+    "defaults": "webpack-defaults"
   },
   "files": [
     "dist"
@@ -66,7 +66,7 @@
     "prettier": "^1.19.1",
     "standard-version": "^7.1.0",
     "supertest": "^4.0.2",
-    "webpack": "^4.41.3"
+    "webpack": "^4.41.5"
   },
   "keywords": [
     "webpack",

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import express from 'express';
 import { Stats } from 'webpack';
 
@@ -199,7 +201,15 @@ describe('API', () => {
 
   describe('getFilenameFromUrl method', () => {
     it('use publicPath and compiler.outputPath to parse the filename', () => {
-      const filename = instance.getFilenameFromUrl('/public/index.html');
+      const filename = instance.getFilenameFromUrl('/public/index.html', {
+        compilation: {
+          getPath: (value) => value,
+          outputOptions: {
+            path: path.resolve(__dirname, 'foo/bar'),
+            outputPath: '/',
+          },
+        },
+      });
 
       expect(filename.endsWith('/public/index.html')).toBe(true);
     });

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -571,7 +571,7 @@ describe('middleware', () => {
         request(app)
           .get(
             isWebpack5()
-              ? '/static/4c347cd8af8b39e58cbf/bundle.js'
+              ? '/static/45c13f171499f5100d88/bundle.js'
               : '/static/4c347cd8af8b39e58cbf/bundle.js'
           )
           .expect(200, done);
@@ -633,7 +633,7 @@ describe('middleware', () => {
         request(app)
           .get(
             isWebpack5()
-              ? '/static-one/7ed325c92a1d0fe4ce64/bundle.js'
+              ? '/static-one/a9739b1fa1e4eb31790f/bundle.js'
               : '/static-one/7ed325c92a1d0fe4ce64/bundle.js'
           )
           .expect(200, done);
@@ -643,7 +643,7 @@ describe('middleware', () => {
         request(app)
           .get(
             isWebpack5()
-              ? '/static-two/db47aa827bb52e5f2e6b/bundle.js'
+              ? '/static-two/a819fc976c8e917e69c6/bundle.js'
               : '/static-two/db47aa827bb52e5f2e6b/bundle.js'
           )
           .expect(200, done);
@@ -1768,7 +1768,7 @@ describe('middleware', () => {
         request(app)
           .get(
             isWebpack5()
-              ? '/static/4c347cd8af8b39e58cbf/bundle.js'
+              ? '/static/45c13f171499f5100d88/bundle.js'
               : '/static/4c347cd8af8b39e58cbf/bundle.js'
           )
           .expect(200, (error) => {
@@ -1779,7 +1779,7 @@ describe('middleware', () => {
             const bundlePath = isWebpack5()
               ? path.resolve(
                   __dirname,
-                  './outputs/write-to-disk-with-hash/dist_6e9d1c41483198efea74/bundle.js'
+                  './outputs/write-to-disk-with-hash/dist_45c13f171499f5100d88/bundle.js'
                 )
               : path.resolve(
                   __dirname,


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Changes:
- respect `publicPath` value from `output.path`
- fix using `[hash]`/`[fullhash]` in `output.path` and `output.publicPath` options
- fix broken test
- remove invalid check on `HASH`, a developer can use any filename for any files
- we need use `stats` to get output path and public path

### Breaking Changes

Yes, default value of `publicPath` is `output.publicPath`

### Additional Info

We recommend use a same value for `publicPath` and for `output.publicPath` so let's do it by default for 0CJS https://github.com/webpack/webpack-dev-middleware#publicpath