### PR TITLE
Refactor code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10190,6 +10190,14 @@
       "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
       "dev": true
     },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -10227,6 +10235,22 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
+    },
+    "mem": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-6.0.1.tgz",
+      "integrity": "sha512-uIRYASflIsXqvKe+7aXbLrydaRzz4qiK6amqZDQI++eRtW3UoKtnDcGeCAOREgll7YMxO5E4VB9+3B0LFmy96g==",
+      "requires": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.0.0.tgz",
+          "integrity": "sha512-PiVO95TKvhiwgSwg1IdLYlCTdul38yZxZMIcnDSFIBUm4BNZha2qpQ4GpJ++15bHoKDtrW2D69lMfFwdFYtNZQ=="
+        }
+      }
     },
     "memfs": {
       "version": "3.0.4",
@@ -10950,6 +10974,11 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
     },
     "p-each-series": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "webpack": "^4.0.0"
   },
   "dependencies": {
+    "mem": "^6.0.1",
     "memfs": "^3.0.4",
     "mime-types": "^2.1.26",
     "range-parser": "^1.2.1",

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ import setupHooks from './utils/setupHooks';
 import setupLogger from './utils/setupLogger';
 import setupWriteToDisk from './utils/setupWriteToDisk';
 import setupOutputFileSystem from './utils/setupOutputFileSystem';
-import getFilenameFromUrl from './utils/getFilenameFromUrl';
 import ready from './utils/ready';
 import schema from './options.json';
 
@@ -88,8 +87,6 @@ export default function wdm(compiler, options = {}) {
 
       context.watching.close(callback);
     },
-
-    getFilenameFromUrl: getFilenameFromUrl.bind(this, context),
 
     context,
   });

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -3,7 +3,7 @@ import path from 'path';
 import mime from 'mime-types';
 
 import DevMiddlewareError from './DevMiddlewareError';
-import getFilenameFromUrl from './utils/getFilenameFromUrl';
+import getPossibleFilePaths from './utils/getPossibleFilePaths';
 import handleRangeHeaders from './utils/handleRangeHeaders';
 import ready from './utils/ready';
 
@@ -44,7 +44,7 @@ export default function wrapper(context) {
     return new Promise((resolve) => {
       // eslint-disable-next-line consistent-return
       function processRequest(stats) {
-        const possibleFilePaths = getFilenameFromUrl(context, req.url, stats);
+        const possibleFilePaths = getPossibleFilePaths(context, req.url, stats);
 
         if (possibleFilePaths.length === 0) {
           return goNext();

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -9,8 +9,7 @@ import ready from './utils/ready';
 
 export default function wrapper(context) {
   return function middleware(req, res, next) {
-    // fixes #282. credit @cexoso. in certain edge situations res.locals is
-    // undefined.
+    // fixes #282. credit @cexoso. in certain edge situations res.locals is undefined.
     // eslint-disable-next-line no-param-reassign
     res.locals = res.locals || {};
 
@@ -47,7 +46,7 @@ export default function wrapper(context) {
       function processRequest(stats) {
         let filename = getFilenameFromUrl(context, req.url, stats);
 
-        if (filename === false) {
+        if (!filename) {
           return goNext();
         }
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -44,15 +44,27 @@ export default function wrapper(context) {
     return new Promise((resolve) => {
       // eslint-disable-next-line consistent-return
       function processRequest(stats) {
-        let filename = getFilenameFromUrl(context, req.url, stats);
+        const possibleFilePaths = getFilenameFromUrl(context, req.url, stats);
 
-        if (!filename) {
+        if (possibleFilePaths.length === 0) {
           return goNext();
         }
 
-        try {
-          let stat = context.outputFileSystem.statSync(filename);
+        let filePath;
+        let stat;
 
+        for (const possibleFilePath of possibleFilePaths) {
+          try {
+            stat = context.outputFileSystem.statSync(possibleFilePath);
+          } catch (_ignoreError) {
+            // eslint-disable-next-line no-continue
+            continue;
+          }
+
+          filePath = possibleFilePath;
+        }
+
+        try {
           if (!stat.isFile()) {
             if (stat.isDirectory()) {
               let { index } = context.options;
@@ -64,8 +76,8 @@ export default function wrapper(context) {
                 throw new DevMiddlewareError('next');
               }
 
-              filename = path.posix.join(filename, index);
-              stat = context.outputFileSystem.statSync(filename);
+              filePath = path.join(filePath, index);
+              stat = context.outputFileSystem.statSync(filePath);
 
               if (!stat.isFile()) {
                 throw new DevMiddlewareError('next');
@@ -82,7 +94,7 @@ export default function wrapper(context) {
         let content;
 
         try {
-          content = context.outputFileSystem.readFileSync(filename);
+          content = context.outputFileSystem.readFileSync(filePath);
         } catch (_ignoreError) {
           return resolve(goNext());
         }
@@ -90,7 +102,7 @@ export default function wrapper(context) {
         content = handleRangeHeaders(content, req, res);
 
         if (!res.get('Content-Type')) {
-          const contentType = mime.contentType(path.extname(filename));
+          const contentType = mime.contentType(path.extname(filePath));
 
           if (contentType) {
             res.set('Content-Type', contentType);

--- a/src/utils/getFilenameFromUrl.js
+++ b/src/utils/getFilenameFromUrl.js
@@ -54,6 +54,7 @@ export default function getFilenameFromUrl(context, url, stats) {
   const { options } = context;
   const { outputPath, publicPath } = getPaths(stats, options, url);
   // localPrefix is the folder our bundle should be in
+  // TODO catch error
   const localPrefix = parse(publicPath || '/', false, true);
   const urlObject = parse(url);
   const hostNameIsTheSame = localPrefix.hostname === urlObject.hostname;
@@ -89,29 +90,18 @@ export default function getFilenameFromUrl(context, url, stats) {
 
   let uri = outputPath;
 
-  /* istanbul ignore if */
-  if (process.platform === 'win32') {
-    // Path Handling for Microsoft Windows
-    if (filename) {
-      uri = path.posix.join(outputPath, querystring.unescape(filename));
+  // Path Handling for all other operating systems
+  if (filename) {
+    uri = path.posix.join(outputPath, querystring.unescape(filename));
 
+    if (process.platform === 'win32') {
       if (!path.win32.isAbsolute(uri)) {
         uri = `/${uri}`;
       }
-    }
-
-    return uri;
-  }
-
-  // Path Handling for all other operating systems
-  if (filename) {
-    uri = path.posix.join(outputPath, filename);
-
-    if (!path.posix.isAbsolute(uri)) {
+    } else if (!path.posix.isAbsolute(uri)) {
       uri = `/${uri}`;
     }
   }
 
-  // if no matches, use outputPath as filename
-  return querystring.unescape(uri);
+  return uri;
 }

--- a/src/utils/getFilenameFromUrl.js
+++ b/src/utils/getFilenameFromUrl.js
@@ -5,12 +5,10 @@ import querystring from 'querystring';
 import mem from 'mem';
 
 function getPaths(stats, options) {
-  const multipleStats = stats.stats ? stats.stats : [stats];
-
+  const childStats = stats.stats ? stats.stats : [stats];
   const publicPaths = [];
 
-  for (const childStats of multipleStats) {
-    const { compilation } = childStats;
+  for (const { compilation } of childStats) {
     // The `output.path` is always present and always absolute
     const outputPath = compilation.getPath(compilation.outputOptions.path);
     const publicPath = options.publicPath

--- a/src/utils/getFilenameFromUrl.js
+++ b/src/utils/getFilenameFromUrl.js
@@ -71,7 +71,6 @@ export default function getFilenameFromUrl(context, url, stats) {
     return false;
   }
 
-  // Absolute and
   // The `publicPath` option has the `protocol` property that is not the same as request url's, should fail
   // The `publicPath` option has the `auth` property that is not the same as request url's, should fail
   // The `publicPath` option has the `host` property that is not the same as request url's, should fail
@@ -85,17 +84,6 @@ export default function getFilenameFromUrl(context, url, stats) {
     (publicPathObject.host !== null &&
       urlObject.host !== null &&
       publicPathObject.host !== urlObject.host)
-  ) {
-    return false;
-  }
-
-  // The `publicPath` option has the `host` property.
-  // The requested url doesn't contain the `host` property.
-  // But the `pathname` property of the requested url doesn't start with `pathname` property of `publicPath`, should fail
-  if (
-    publicPathObject.host &&
-    !urlObject.host &&
-    !urlObject.pathname.startsWith(publicPathObject.pathname)
   ) {
     return false;
   }

--- a/src/utils/getFilenameFromUrl.js
+++ b/src/utils/getFilenameFromUrl.js
@@ -92,13 +92,9 @@ export default function getFilenameFromUrl(context, url, stats) {
 
   // Path Handling for all other operating systems
   if (filename) {
-    uri = path.posix.join(outputPath, querystring.unescape(filename));
+    uri = path.join(outputPath, querystring.unescape(filename));
 
-    if (process.platform === 'win32') {
-      if (!path.win32.isAbsolute(uri)) {
-        uri = `/${uri}`;
-      }
-    } else if (!path.posix.isAbsolute(uri)) {
+    if (!path.isAbsolute(uri)) {
       uri = `/${uri}`;
     }
   }

--- a/src/utils/getFilenameFromUrl.js
+++ b/src/utils/getFilenameFromUrl.js
@@ -4,92 +4,72 @@ import querystring from 'querystring';
 
 import mem from 'mem';
 
-function getPaths(stats, options, url) {
-  let outputPath;
-  let publicPath;
+function getPaths(stats, options) {
+  const multipleStats = stats.stats ? stats.stats : [stats];
 
-  if (stats.stats) {
-    for (let i = 0; i < stats.stats.length; i++) {
-      const { compilation } = stats.stats[i];
+  const publicPaths = [];
 
-      publicPath = options.publicPath
-        ? compilation.getPath(options.publicPath)
-        : compilation.outputOptions.publicPath
-        ? compilation.getPath(compilation.outputOptions.publicPath)
-        : '';
-
-      if (publicPath) {
-        outputPath = compilation.outputOptions.path
-          ? compilation.getPath(compilation.outputOptions.path)
-          : '';
-
-        // Handle the case where publicPath is a URL with hostname
-        // TODO what the fuck ?!
-        const publicPathPathname =
-          publicPath.indexOf('/') === 0
-            ? publicPath
-            : parse(publicPath).pathname;
-
-        // Check the url vs the path part of the publicPath
-        if (url.indexOf(publicPathPathname) === 0) {
-          return { publicPath, outputPath };
-        }
-      }
-    }
-  } else {
-    const { compilation } = stats;
-
-    outputPath = compilation.outputOptions.path
-      ? compilation.getPath(compilation.outputOptions.path)
-      : '';
-    publicPath = options.publicPath
+  for (const childStats of multipleStats) {
+    const { compilation } = childStats;
+    // The `output.path` is always present and always absolute
+    const outputPath = compilation.getPath(compilation.outputOptions.path);
+    const publicPath = options.publicPath
       ? compilation.getPath(options.publicPath)
       : compilation.outputOptions.publicPath
       ? compilation.getPath(compilation.outputOptions.publicPath)
       : '';
+
+    publicPaths.push({ outputPath, publicPath });
   }
 
-  return { outputPath, publicPath };
+  return publicPaths;
 }
 
 const memoizedParse = mem(parse);
 
 export default function getFilenameFromUrl(context, url, stats) {
   const { options } = context;
-  const { outputPath, publicPath } = getPaths(stats, options, url);
-
-  let publicPathObject;
-
-  try {
-    publicPathObject = memoizedParse(publicPath || '/', false, true);
-  } catch (_ignoreError) {
-    return false;
-  }
+  const paths = getPaths(stats, options);
 
   let urlObject;
+  let pathToFile;
 
   try {
     // The `url` property of the `request` is contains only  `pathname`, `search` and `hash`
     urlObject = memoizedParse(url, false, true);
   } catch (_ignoreError) {
-    return false;
+    return pathToFile;
   }
 
-  // The `pathname` property of the requested url doesn't start with `pathname` property of `publicPath`, should fail
-  if (!urlObject.pathname.startsWith(publicPathObject.pathname)) {
-    return false;
+  for (const childPaths of paths) {
+    const { publicPath, outputPath } = childPaths;
+
+    let publicPathObject;
+
+    try {
+      publicPathObject = memoizedParse(publicPath || '/', false, true);
+    } catch (_ignoreError) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    if (urlObject.pathname.startsWith(publicPathObject.pathname)) {
+      pathToFile = outputPath;
+
+      // Strip the `pathname` property from the `publicPath` option from the start of requested url
+      // `/complex/foo.js` => `foo.js`
+      const filename = urlObject.pathname.substr(
+        publicPathObject.pathname.length
+      );
+
+      // Forming the path to the file
+      if (filename) {
+        pathToFile = path.join(outputPath, querystring.unescape(filename));
+      }
+
+      break;
+    }
   }
 
-  let uri = outputPath;
-
-  // Strip the `pathname` property from the `publicPath` option from the start of requested url
-  // `/complex/foo.js` => `foo.js`
-  const filename = urlObject.pathname.substr(publicPathObject.pathname.length);
-
-  // Forming the path to the file
-  if (filename) {
-    uri = path.join(outputPath, querystring.unescape(filename));
-  }
-
-  return uri;
+  return pathToFile;
 }

--- a/src/utils/getFilenameFromUrl.js
+++ b/src/utils/getFilenameFromUrl.js
@@ -41,9 +41,7 @@ export default function getFilenameFromUrl(context, url, stats) {
     return pathToFile;
   }
 
-  for (const childPaths of paths) {
-    const { publicPath, outputPath } = childPaths;
-
+  for (const { publicPath, outputPath } of paths) {
     let publicPathObject;
 
     try {

--- a/src/utils/getFilenameFromUrl.js
+++ b/src/utils/getFilenameFromUrl.js
@@ -13,7 +13,7 @@ function getPaths(stats, options, url) {
       const { compilation } = stats.stats[i];
 
       publicPath = options.publicPath
-        ? options.publicPath
+        ? compilation.getPath(options.publicPath)
         : compilation.outputOptions.publicPath
         ? compilation.getPath(compilation.outputOptions.publicPath)
         : '';
@@ -43,7 +43,7 @@ function getPaths(stats, options, url) {
       ? compilation.getPath(compilation.outputOptions.path)
       : '';
     publicPath = options.publicPath
-      ? options.publicPath
+      ? compilation.getPath(options.publicPath)
       : compilation.outputOptions.publicPath
       ? compilation.getPath(compilation.outputOptions.publicPath)
       : '';
@@ -89,10 +89,6 @@ export default function getFilenameFromUrl(context, url, stats) {
   // Forming the path to the file
   if (filename) {
     uri = path.join(outputPath, querystring.unescape(filename));
-
-    if (!path.isAbsolute(uri)) {
-      uri = `/${uri}`;
-    }
   }
 
   return uri;

--- a/src/utils/getFilenameFromUrl.js
+++ b/src/utils/getFilenameFromUrl.js
@@ -88,21 +88,23 @@ export default function getFilenameFromUrl(context, url, stats) {
     return false;
   }
 
+  // The `publicPath` option has the `host` property.
+  // The requested url doesn't contain the `host` property.
+  // But the `pathname` property of the requested url doesn't start with `pathname` property of `publicPath`.
+  if (
+    publicPathObject.host &&
+    !urlObject.host &&
+    !urlObject.pathname.startsWith(publicPathObject.pathname)
+  ) {
+    return false;
+  }
+
   // publicPath is not in url, so it should fail
   // TODO test
   if (
     publicPath &&
     publicPathObject.host === urlObject.host &&
     url.indexOf(publicPath) !== 0
-  ) {
-    return false;
-  }
-
-  // TODO test
-  if (
-    !urlObject.hostname &&
-    publicPathObject.hostname &&
-    url.indexOf(publicPathObject.path) !== 0
   ) {
     return false;
   }

--- a/src/utils/getFilenameFromUrl.js
+++ b/src/utils/getFilenameFromUrl.js
@@ -66,21 +66,21 @@ export default function getFilenameFromUrl(context, url, stats) {
   let urlObject;
 
   try {
-    urlObject = parse(url);
+    urlObject = parse(url, false, true);
   } catch (_ignoreError) {
     return false;
   }
 
+  // The `publicPath` option has the `protocol` property that is not the same as request url's, should fail
+  // The `publicPath` option has the `auth` property that is not the same as request url's, should fail
+  // The `publicPath` option has the `host` property that is not the same as request url's, should fail
   if (
-    // The `publicPath` option has the `protocol` that is not the same as request url's, should fail
     (publicPathObject.protocol !== null &&
       urlObject.protocol !== null &&
       publicPathObject.protocol !== urlObject.protocol) ||
-    // The `publicPath` option has the `auth` that is not the same as request url's, should fail
     (publicPathObject.auth !== null &&
       urlObject.auth !== null &&
       publicPathObject.auth !== urlObject.auth) ||
-    // The `publicPath` option has the `host` that is not the same as request url's, should fail
     (publicPathObject.host !== null &&
       urlObject.host !== null &&
       publicPathObject.host !== urlObject.host)
@@ -90,7 +90,7 @@ export default function getFilenameFromUrl(context, url, stats) {
 
   // The `publicPath` option has the `host` property.
   // The requested url doesn't contain the `host` property.
-  // But the `pathname` property of the requested url doesn't start with `pathname` property of `publicPath`.
+  // But the `pathname` property of the requested url doesn't start with `pathname` property of `publicPath`, should fail
   if (
     publicPathObject.host &&
     !urlObject.host &&

--- a/src/utils/getFilenameFromUrl.js
+++ b/src/utils/getFilenameFromUrl.js
@@ -25,18 +25,21 @@ function getPaths(stats, options) {
 
 const memoizedParse = mem(parse);
 
+// TODO rename
 export default function getFilenameFromUrl(context, url, stats) {
   const { options } = context;
   const paths = getPaths(stats, options);
 
   let urlObject;
-  let pathToFile;
+
+  const pathToFiles = [];
 
   try {
     // The `url` property of the `request` is contains only  `pathname`, `search` and `hash`
     urlObject = memoizedParse(url, false, true);
   } catch (_ignoreError) {
-    return pathToFile;
+    // eslint-disable-next-line no-undefined
+    return pathToFiles;
   }
 
   for (const { publicPath, outputPath } of paths) {
@@ -50,7 +53,7 @@ export default function getFilenameFromUrl(context, url, stats) {
     }
 
     if (urlObject.pathname.startsWith(publicPathObject.pathname)) {
-      pathToFile = outputPath;
+      let pathToFile = outputPath;
 
       // Strip the `pathname` property from the `publicPath` option from the start of requested url
       // `/complex/foo.js` => `foo.js`
@@ -63,9 +66,9 @@ export default function getFilenameFromUrl(context, url, stats) {
         pathToFile = path.join(outputPath, querystring.unescape(filename));
       }
 
-      break;
+      pathToFiles.push(pathToFile);
     }
   }
 
-  return pathToFile;
+  return pathToFiles;
 }

--- a/src/utils/getFilenameFromUrl.js
+++ b/src/utils/getFilenameFromUrl.js
@@ -71,6 +71,7 @@ export default function getFilenameFromUrl(context, url, stats) {
     return false;
   }
 
+  // Absolute and
   // The `publicPath` option has the `protocol` property that is not the same as request url's, should fail
   // The `publicPath` option has the `auth` property that is not the same as request url's, should fail
   // The `publicPath` option has the `host` property that is not the same as request url's, should fail
@@ -99,24 +100,16 @@ export default function getFilenameFromUrl(context, url, stats) {
     return false;
   }
 
-  // publicPath is not in url, so it should fail
-  // TODO test
-  if (
-    publicPath &&
-    publicPathObject.host === urlObject.host &&
-    url.indexOf(publicPath) !== 0
-  ) {
+  // The `pathname` property of the requested url doesn't start with `pathname` property of `publicPath`, should fail
+  if (!urlObject.pathname.startsWith(publicPathObject.pathname)) {
     return false;
   }
 
   let uri = outputPath;
-  let filename;
 
   // Strip the `pathname` property from the `publicPath` option from the start of requested url
   // `/complex/foo.js` => `foo.js`
-  if (urlObject.pathname.startsWith(publicPathObject.pathname)) {
-    filename = urlObject.pathname.substr(publicPathObject.pathname.length);
-  }
+  const filename = urlObject.pathname.substr(publicPathObject.pathname.length);
 
   // Forming the path to the file
   if (filename) {

--- a/src/utils/getPossibleFilePaths.js
+++ b/src/utils/getPossibleFilePaths.js
@@ -25,8 +25,7 @@ function getPaths(stats, options) {
 
 const memoizedParse = mem(parse);
 
-// TODO rename
-export default function getFilenameFromUrl(context, url, stats) {
+export default (context, url, stats) => {
   const { options } = context;
   const paths = getPaths(stats, options);
 
@@ -71,4 +70,4 @@ export default function getFilenameFromUrl(context, url, stats) {
   }
 
   return pathToFiles;
-}
+};

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,5 +1,3 @@
-import path from 'path';
-
 import express from 'express';
 import { Stats } from 'webpack';
 
@@ -196,28 +194,6 @@ describe('API', () => {
           done();
         });
       });
-    });
-  });
-
-  describe('getFilenameFromUrl method', () => {
-    it('use publicPath and compiler.outputPath to parse the filename', () => {
-      const [filename] = instance.getFilenameFromUrl('/public/index.html', {
-        compilation: {
-          getPath: (value) => value,
-          outputOptions: {
-            path: path.resolve(__dirname, 'foo/bar'),
-            outputPath: '/',
-          },
-        },
-      });
-
-      const isWindows = process.platform === 'win32';
-
-      expect(
-        isWindows
-          ? filename.endsWith('\\public\\index.html')
-          : filename.endsWith('/public/index.html')
-      ).toBe(true);
     });
   });
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -211,7 +211,13 @@ describe('API', () => {
         },
       });
 
-      expect(filename.endsWith('/public/index.html')).toBe(true);
+      const isWindows = process.platform === 'win32';
+
+      expect(
+        isWindows
+          ? filename.endsWith('\\public\\index.html')
+          : filename.endsWith('/public/index.html')
+      ).toBe(true);
     });
   });
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -201,7 +201,7 @@ describe('API', () => {
 
   describe('getFilenameFromUrl method', () => {
     it('use publicPath and compiler.outputPath to parse the filename', () => {
-      const filename = instance.getFilenameFromUrl('/public/index.html', {
+      const [filename] = instance.getFilenameFromUrl('/public/index.html', {
         compilation: {
           getPath: (value) => value,
           outputOptions: {

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -700,10 +700,10 @@ describe('middleware', () => {
           .expect(404, done);
       });
 
-      it('should return 200 code for GET request to non-public path', (done) => {
+      it('should return 404 code for GET request to non-public path', (done) => {
         request(app)
           .get('/')
-          .expect(200, done);
+          .expect(404, done);
       });
     });
 

--- a/test/utils/getFilenameFromUrl.test.js
+++ b/test/utils/getFilenameFromUrl.test.js
@@ -94,6 +94,14 @@ describe('GetFilenameFromUrl', () => {
     },
     {
       outputOptions: {
+        path: '/',
+        publicPath: '/',
+      },
+      url: '/test.html?foo=bar#hash',
+      expected: '/test.html',
+    },
+    {
+      outputOptions: {
         path: '/dist',
         publicPath: '/',
       },
@@ -191,6 +199,22 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       expected: '/pathname with spaces.js',
+    },
+    {
+      url: '/dirname%20with%20spaces/filename%20with%20spaces.js',
+      outputOptions: {
+        path: '/',
+        publicPath: '/',
+      },
+      expected: '/dirname with spaces/filename with spaces.js',
+    },
+    {
+      url: '/dirname%20with%20spaces/filename%20with%20spaces.js',
+      outputOptions: {
+        path: '/',
+        publicPath: '/',
+      },
+      expected: '/dirname with spaces/filename with spaces.js',
     },
     {
       url: '/js/sample.js',

--- a/test/utils/getFilenameFromUrl.test.js
+++ b/test/utils/getFilenameFromUrl.test.js
@@ -6,9 +6,13 @@ function testUrl(test) {
   const context = { options: {} };
   const stats = getStatsMock(test.outputOptions);
 
-  expect(getFilenameFromUrl(context, test.url, stats)).toBe(
-    isWindows ? test.expected.replace(/\\/g, '/') : test.expected
-  );
+  let { expected } = test;
+
+  if (typeof expected !== 'undefined' && isWindows) {
+    expected = expected.replace(/\//g, '\\');
+  }
+
+  expect(getFilenameFromUrl(context, test.url, stats)).toBe(expected);
 }
 
 function getStatsMock(outputOptions) {

--- a/test/utils/getFilenameFromUrl.test.js
+++ b/test/utils/getFilenameFromUrl.test.js
@@ -6,7 +6,9 @@ function testUrl(test) {
   const context = { options: {} };
   const stats = getStatsMock(test.outputOptions);
 
-  expect(getFilenameFromUrl(context, test.url, stats)).toBe(test.expected);
+  expect(getFilenameFromUrl(context, test.url, stats)).toBe(
+    isWindows ? test.expected.replace(/\\/g, '/') : test.expected
+  );
 }
 
 function getStatsMock(outputOptions) {

--- a/test/utils/getFilenameFromUrl.test.js
+++ b/test/utils/getFilenameFromUrl.test.js
@@ -28,10 +28,7 @@ function getStatsMock(outputOptions) {
 describe('GetFilenameFromUrl', () => {
   const tests = [
     {
-      outputOptions: {
-        path: '/',
-        publicPath: '/',
-      },
+      outputOptions: {},
       url: '/foo.js',
       expected: '/foo.js',
     },
@@ -46,7 +43,20 @@ describe('GetFilenameFromUrl', () => {
       expected: '/foo.js',
     },
     {
-      outputOptions: {},
+      outputOptions: {
+        // eslint-disable-next-line no-undefined
+        path: undefined,
+        // eslint-disable-next-line no-undefined
+        publicPath: undefined,
+      },
+      url: '/complex/foo.js',
+      expected: '/complex/foo.js',
+    },
+    {
+      outputOptions: {
+        path: '/',
+        publicPath: '/',
+      },
       url: '/foo.js',
       expected: '/foo.js',
     },
@@ -67,6 +77,38 @@ describe('GetFilenameFromUrl', () => {
       },
       url: '/%foo%/%foo%.js',
       expected: '/%foo%/%foo%.js',
+    },
+    {
+      outputOptions: {
+        path: '/',
+        publicPath: '/complex',
+      },
+      url: '/complex/foo.js',
+      expected: '/foo.js',
+    },
+    {
+      outputOptions: {
+        path: '/',
+        publicPath: 'http://localhost:8081/complex/',
+      },
+      url: 'http://localhost:8080/complex/foo.js',
+      expected: false,
+    },
+    {
+      outputOptions: {
+        path: '/',
+        publicPath: 'http://localhost:8080/complex/',
+      },
+      url: 'https://localhost:8080/complex/foo.js',
+      expected: false,
+    },
+    {
+      outputOptions: {
+        path: '/',
+        publicPath: 'http://foo:pass@localhost:8080/complex/',
+      },
+      url: 'http://bar:pass@localhost:8080/complex/foo.js',
+      expected: false,
     },
     {
       outputOptions: {
@@ -136,84 +178,84 @@ describe('GetFilenameFromUrl', () => {
       expected: '/a/more/complex/path.js',
     },
     {
-      url: '/more/complex/path.js',
       outputOptions: {
         path: '/a',
         publicPath: '/complex',
       },
+      url: '/more/complex/path.js',
       expected: false,
     },
     {
-      url: 'c.js',
+      // publicPath is not in url, so it should fail
       outputOptions: {
         path: '/dist',
         publicPath: '/',
       },
-      // publicPath is not in url, so it should fail
+      url: 'c.js',
       expected: false,
     },
     {
-      url: '/bar/',
       outputOptions: {
         path: '/foo',
         publicPath: '/bar/',
       },
+      url: '/bar/',
       expected: '/foo',
     },
     {
-      url: '/bar/',
       outputOptions: {
         path: '/',
         publicPath: 'http://localhost/foo/',
       },
+      url: '/bar/',
       expected: false,
     },
     {
-      url: 'http://test.domain/test/sample.js',
       outputOptions: {
         path: '/',
         publicPath: '/test/',
       },
+      url: 'http://test.domain/test/sample.js',
       expected: '/sample.js',
     },
     {
-      url: 'http://test.domain/test/sample.js',
       outputOptions: {
         path: '/',
         publicPath: 'http://other.domain/test/',
       },
+      url: 'http://test.domain/test/sample.js',
       expected: false,
     },
     {
-      url: '/protocol/relative/sample.js',
       outputOptions: {
         path: '/',
         publicPath: '//test.domain/protocol/relative/',
       },
+      url: '/protocol/relative/sample.js',
       expected: '/sample.js',
     },
     {
-      url: '/pathname%20with%20spaces.js',
       outputOptions: {
         path: '/',
         publicPath: '/',
       },
+      url: '/pathname%20with%20spaces.js',
       expected: '/pathname with spaces.js',
     },
     {
-      url: '/dirname%20with%20spaces/filename%20with%20spaces.js',
       outputOptions: {
         path: '/',
         publicPath: '/',
       },
+      url: '/dirname%20with%20spaces/filename%20with%20spaces.js',
       expected: '/dirname with spaces/filename with spaces.js',
     },
     {
-      url: '/dirname%20with%20spaces/filename%20with%20spaces.js',
       outputOptions: {
         path: '/',
         publicPath: '/',
       },
+      url: '/dirname%20with%20spaces/filename%20with%20spaces.js',
       expected: '/dirname with spaces/filename with spaces.js',
     },
     {
@@ -225,7 +267,6 @@ describe('GetFilenameFromUrl', () => {
       expected: '/static/foo.js',
     },
     {
-      url: '/js/sample.js',
       outputOptions: [
         {
           path: '/foo',
@@ -236,10 +277,10 @@ describe('GetFilenameFromUrl', () => {
           publicPath: '/css/',
         },
       ],
+      url: '/js/sample.js',
       expected: '/foo/sample.js',
     },
     {
-      url: '/js/sample.js',
       outputOptions: [
         {
           path: '/foo',
@@ -250,10 +291,10 @@ describe('GetFilenameFromUrl', () => {
           publicPath: 'http://localhost/css/',
         },
       ],
+      url: '/js/sample.js',
       expected: '/foo/sample.js',
     },
     {
-      url: '/css/sample.css',
       outputOptions: [
         {
           path: '/foo',
@@ -264,10 +305,10 @@ describe('GetFilenameFromUrl', () => {
           publicPath: '/css/',
         },
       ],
+      url: '/css/sample.css',
       expected: '/bar/sample.css',
     },
     {
-      url: '/css/sample.css',
       outputOptions: [
         {
           path: '/foo',
@@ -278,24 +319,24 @@ describe('GetFilenameFromUrl', () => {
           publicPath: 'http://localhost/css/',
         },
       ],
+      url: '/css/sample.css',
       expected: '/bar/sample.css',
     },
     {
+      outputOptions: [
+        {
+          path: '/foo',
+          publicPath: '/js/',
+        },
+        {
+          path: '/bar',
+          publicPath: '/css/',
+        },
+      ],
       url: '/other/sample.txt',
-      outputOptions: [
-        {
-          path: '/foo',
-          publicPath: '/js/',
-        },
-        {
-          path: '/bar',
-          publicPath: '/css/',
-        },
-      ],
       expected: false,
     },
     {
-      url: '/other/sample.txt',
       outputOptions: [
         {
           path: '/foo',
@@ -306,11 +347,11 @@ describe('GetFilenameFromUrl', () => {
           publicPath: 'http://localhost/css/',
         },
       ],
+      url: '/other/sample.txt',
       expected: false,
     },
 
     {
-      url: '/js/sample.js',
       outputOptions: [
         {
           path: '/foo',
@@ -320,10 +361,10 @@ describe('GetFilenameFromUrl', () => {
           path: '/bar',
         },
       ],
+      url: '/js/sample.js',
       expected: '/foo/sample.js',
     },
     {
-      url: '/css/sample.css',
       outputOptions: [
         {
           path: '/foo',
@@ -333,10 +374,10 @@ describe('GetFilenameFromUrl', () => {
           publicPath: '/css/',
         },
       ],
+      url: '/css/sample.css',
       expected: '/bar/sample.css',
     },
     {
-      url: '/js/sample.js',
       outputOptions: [
         {
           publicPath: '/js/',
@@ -346,10 +387,10 @@ describe('GetFilenameFromUrl', () => {
           publicPath: '/css/',
         },
       ],
+      url: '/js/sample.js',
       expected: '/sample.js',
     },
     {
-      url: '/css/sample.css',
       outputOptions: [
         {
           path: '/foo',
@@ -359,10 +400,10 @@ describe('GetFilenameFromUrl', () => {
           publicPath: '/css/',
         },
       ],
+      url: '/css/sample.css',
       expected: '/sample.css',
     },
     {
-      url: '/js/sample.js',
       outputOptions: [
         {
           path: '/foo',
@@ -373,10 +414,10 @@ describe('GetFilenameFromUrl', () => {
           publicPath: '/css/',
         },
       ],
+      url: '/js/sample.js',
       expected: '/foo/sample.js',
     },
     {
-      url: '/js/sample.js',
       outputOptions: [
         {
           path: '/foo',
@@ -387,10 +428,10 @@ describe('GetFilenameFromUrl', () => {
           publicPath: 'http://localhost/css/',
         },
       ],
+      url: '/js/sample.js',
       expected: '/foo/sample.js',
     },
     {
-      url: '/css/sample.css',
       outputOptions: [
         {
           path: '/foo',
@@ -401,10 +442,10 @@ describe('GetFilenameFromUrl', () => {
           publicPath: '/css/',
         },
       ],
+      url: '/css/sample.css',
       expected: '/bar/sample.css',
     },
     {
-      url: '/css/sample.css',
       outputOptions: [
         {
           path: '/foo',
@@ -415,10 +456,10 @@ describe('GetFilenameFromUrl', () => {
           publicPath: 'http://localhost/css/',
         },
       ],
+      url: '/css/sample.css',
       expected: '/bar/sample.css',
     },
     {
-      url: '/other/sample.txt',
       outputOptions: [
         {
           path: '/foo',
@@ -429,10 +470,10 @@ describe('GetFilenameFromUrl', () => {
           publicPath: '/css/',
         },
       ],
+      url: '/other/sample.txt',
       expected: false,
     },
     {
-      url: '/other/sample.txt',
       outputOptions: [
         {
           path: '/foo',
@@ -443,10 +484,10 @@ describe('GetFilenameFromUrl', () => {
           publicPath: 'http://localhost/css/',
         },
       ],
+      url: '/other/sample.txt',
       expected: false,
     },
     {
-      url: '/test/sample.txt',
       outputOptions: [
         {
           path: '/foo',
@@ -457,10 +498,10 @@ describe('GetFilenameFromUrl', () => {
           publicPath: '/css/',
         },
       ],
+      url: '/test/sample.txt',
       expected: false,
     },
     {
-      url: '/test/sample.txt',
       outputOptions: [
         {
           path: '/foo',
@@ -471,80 +512,122 @@ describe('GetFilenameFromUrl', () => {
           publicPath: 'http://localhost/css/',
         },
       ],
+      url: '/test/sample.txt',
       expected: false,
     },
     {
-      url: '/test/sample.txt',
       outputOptions: {
         path: '/test/#leadinghash',
         publicPath: '/',
       },
+      url: '/test/sample.txt',
       expected: '/test/#leadinghash/test/sample.txt',
     },
     {
-      url: '/folder-name-with-dots/mono-v6.x.x',
       outputOptions: {
         path: '/',
         publicPath: '/',
       },
+      url: '/folder-name-with-dots/mono-v6.x.x',
       expected: '/folder-name-with-dots/mono-v6.x.x',
     },
+    {
+      outputOptions: {
+        path: '/',
+        publicPath: '/',
+      },
+      url: '%',
+      expected: false,
+    },
+    {
+      outputOptions: {
+        path: '/',
+        publicPath: '/',
+      },
+      url: '\uD800',
+      expected: false,
+    },
+    {
+      outputOptions: {
+        path: '/bar/',
+        publicPath: '/foo/',
+      },
+      url: '/foo/\x46\x6F\x6F',
+      expected: '/bar/Foo',
+    },
+    {
+      outputOptions: {
+        path: '/',
+        publicPath: '/complex/',
+      },
+      url: 'https://test:malfor%5Med@test.example.com',
+      expected: false,
+    },
+    {
+      outputOptions: {
+        path: '/',
+        publicPath: 'https://test:malfor%5Med@test.example.com',
+      },
+      url: '/foo/bar',
+      expected: false,
+    },
+
     // Windows tests
     {
       condition: isWindows,
-      url: '/test/windows.txt',
       outputOptions: {
         path: 'c:\\foo',
         publicPath: '/test',
       },
+      url: '/test/windows.txt',
       expected: 'c:\\foo\\windows.txt',
     },
     // Tests for #284
     {
       condition: isWindows,
-      url: '/test/windows.txt',
       outputOptions: {
         path: 'C:\\My%20Path\\wwwroot',
         publicPath: '/test',
       },
+      url: '/test/windows.txt',
       expected: 'C:\\My%20Path\\wwwroot\\windows.txt',
     },
     {
       condition: isWindows,
-      url: '/test/windows%202.txt',
       outputOptions: {
         path: 'C:\\My%20Path\\wwwroot',
         publicPath: '/test',
       },
+      url: '/test/windows%202.txt',
       expected: 'C:\\My%20Path\\wwwroot\\windows 2.txt',
     },
     // Tests for #297
     {
       condition: isWindows,
-      url: '/test/windows.txt',
       outputOptions: {
         path: 'C:\\My Path\\wwwroot',
         publicPath: '/test',
       },
+      url: '/test/windows.txt',
       expected: 'C:\\My Path\\wwwroot\\windows.txt',
     },
     {
       condition: isWindows,
-      url: '/test/windows%202.txt',
       outputOptions: {
         path: 'C:\\My Path\\wwwroot',
         publicPath: '/test',
       },
+      url: '/test/windows%202.txt',
       expected: 'C:\\My Path\\wwwroot\\windows 2.txt',
     },
     // Tests for #284 & #297
     {
       condition: isWindows,
-      url: '/windows%20test/test%20%26%20test%20%26%20%2520.txt',
       outputOptions: {
         path: 'C:\\My %20 Path\\wwwroot',
         publicPath: '/windows%20test',
       },
+      url: '/windows%20test/test%20%26%20test%20%26%20%2520.txt',
       expected: 'C:\\My %20 Path\\wwwroot\\test & test & %20.txt',
     },
   ];

--- a/test/utils/getFilenameFromUrl.test.js
+++ b/test/utils/getFilenameFromUrl.test.js
@@ -160,7 +160,7 @@ describe('GetFilenameFromUrl', () => {
     },
     {
       outputOptions: {
-        path: '/foo',
+        path: isWindows ? '\\foo' : '/foo',
         publicPath: '/bar/',
       },
       url: '/bar/',

--- a/test/utils/getFilenameFromUrl.test.js
+++ b/test/utils/getFilenameFromUrl.test.js
@@ -229,6 +229,14 @@ describe('GetFilenameFromUrl', () => {
     {
       outputOptions: {
         path: '/',
+        publicPath: '//localhost:8080/foo/',
+      },
+      url: '//localhost:8080/foo/index.html',
+      expected: '/index.html',
+    },
+    {
+      outputOptions: {
+        path: '/',
         publicPath: 'http://localhost:8080/foo/',
       },
       url: 'http://localhost:8080/bar/index.html',
@@ -374,7 +382,6 @@ describe('GetFilenameFromUrl', () => {
       url: '/other/sample.txt',
       expected: false,
     },
-
     {
       outputOptions: [
         {

--- a/test/utils/getFilenameFromUrl.test.js
+++ b/test/utils/getFilenameFromUrl.test.js
@@ -213,6 +213,30 @@ describe('GetFilenameFromUrl', () => {
     {
       outputOptions: {
         path: '/',
+        publicPath: 'http://localhost:8080/foo/',
+      },
+      url: '/bar/',
+      expected: false,
+    },
+    {
+      outputOptions: {
+        path: '/',
+        publicPath: 'http://localhost:8080/foo/',
+      },
+      url: 'http://localhost:8080/foo/index.html',
+      expected: '/index.html',
+    },
+    {
+      outputOptions: {
+        path: '/',
+        publicPath: 'http://localhost:8080/foo/',
+      },
+      url: 'http://localhost:8080/bar/index.html',
+      expected: false,
+    },
+    {
+      outputOptions: {
+        path: '/',
         publicPath: '/test/',
       },
       url: 'http://test.domain/test/sample.js',

--- a/test/utils/getFilenameFromUrl.test.js
+++ b/test/utils/getFilenameFromUrl.test.js
@@ -139,7 +139,8 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/complex',
       },
       url: '/more/complex/path.js',
-      expected: false,
+      // eslint-disable-next-line no-undefined
+      expected: undefined,
     },
     {
       // publicPath is not in url, so it should fail
@@ -148,7 +149,8 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       url: 'c.js',
-      expected: false,
+      // eslint-disable-next-line no-undefined
+      expected: undefined,
     },
     {
       outputOptions: {
@@ -164,7 +166,8 @@ describe('GetFilenameFromUrl', () => {
         publicPath: 'http://localhost/foo/',
       },
       url: '/bar/',
-      expected: false,
+      // eslint-disable-next-line no-undefined
+      expected: undefined,
     },
     {
       outputOptions: {
@@ -172,7 +175,8 @@ describe('GetFilenameFromUrl', () => {
         publicPath: 'http://localhost:8080/foo/',
       },
       url: '/bar/',
-      expected: false,
+      // eslint-disable-next-line no-undefined
+      expected: undefined,
     },
     {
       outputOptions: {
@@ -196,7 +200,8 @@ describe('GetFilenameFromUrl', () => {
         publicPath: 'http://localhost:8080/foo/',
       },
       url: 'http://localhost:8080/bar/index.html',
-      expected: false,
+      // eslint-disable-next-line no-undefined
+      expected: undefined,
     },
     {
       outputOptions: {
@@ -336,7 +341,8 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/five/sample.css',
-      expected: false,
+      // eslint-disable-next-line no-undefined
+      expected: undefined,
     },
     {
       outputOptions: [
@@ -350,7 +356,8 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/other/sample.txt',
-      expected: false,
+      // eslint-disable-next-line no-undefined
+      expected: undefined,
     },
     {
       outputOptions: [
@@ -364,7 +371,8 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/other/sample.txt',
-      expected: false,
+      // eslint-disable-next-line no-undefined
+      expected: undefined,
     },
     {
       outputOptions: [
@@ -382,12 +390,12 @@ describe('GetFilenameFromUrl', () => {
     {
       outputOptions: [
         {
-          path: '/foo',
-          publicPath: '',
-        },
-        {
           path: '/bar',
           publicPath: '/css/',
+        },
+        {
+          path: '/foo',
+          publicPath: '',
         },
       ],
       url: '/css/sample.css',
@@ -489,7 +497,8 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/other/sample.txt',
-      expected: false,
+      // eslint-disable-next-line no-undefined
+      expected: undefined,
     },
     {
       outputOptions: [
@@ -503,7 +512,8 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/other/sample.txt',
-      expected: false,
+      // eslint-disable-next-line no-undefined
+      expected: undefined,
     },
     {
       outputOptions: [
@@ -517,7 +527,8 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/test/sample.txt',
-      expected: false,
+      // eslint-disable-next-line no-undefined
+      expected: undefined,
     },
     {
       outputOptions: [
@@ -531,7 +542,8 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/test/sample.txt',
-      expected: false,
+      // eslint-disable-next-line no-undefined
+      expected: undefined,
     },
     {
       outputOptions: {
@@ -555,7 +567,8 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       url: '%',
-      expected: false,
+      // eslint-disable-next-line no-undefined
+      expected: undefined,
     },
     {
       outputOptions: {
@@ -563,7 +576,8 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       url: '\uD800',
-      expected: false,
+      // eslint-disable-next-line no-undefined
+      expected: undefined,
     },
     {
       outputOptions: {
@@ -579,7 +593,8 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/complex/',
       },
       url: 'https://test:malfor%5Med@test.example.com',
-      expected: false,
+      // eslint-disable-next-line no-undefined
+      expected: undefined,
     },
     {
       outputOptions: {
@@ -587,7 +602,8 @@ describe('GetFilenameFromUrl', () => {
         publicPath: 'https://test:malfor%5Med@test.example.com',
       },
       url: '/foo/bar',
-      expected: false,
+      // eslint-disable-next-line no-undefined
+      expected: undefined,
     },
 
     // Windows tests

--- a/test/utils/getFilenameFromUrl.test.js
+++ b/test/utils/getFilenameFromUrl.test.js
@@ -12,7 +12,7 @@ function testUrl(test) {
     expected = expected.replace(/\//g, '\\');
   }
 
-  expect(getFilenameFromUrl(context, test.url, stats)).toBe(expected);
+  expect(getFilenameFromUrl(context, test.url, stats)).toEqual(expected);
 }
 
 function getStatsMock(outputOptions) {
@@ -39,7 +39,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '',
       },
       url: '/foo.js',
-      expected: '/foo.js',
+      expected: ['/foo.js'],
     },
     {
       outputOptions: {
@@ -47,7 +47,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '',
       },
       url: '/complex/foo.js',
-      expected: '/complex/foo.js',
+      expected: ['/complex/foo.js'],
     },
     {
       // Express encodes the URI component, so we do the same
@@ -56,7 +56,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       url: '/f%C3%B6%C3%B6.js',
-      expected: '/föö.js',
+      expected: ['/föö.js'],
     },
     {
       // Filenames can contain characters not allowed in URIs
@@ -65,7 +65,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       url: '/%foo%/%foo%.js',
-      expected: '/%foo%/%foo%.js',
+      expected: ['/%foo%/%foo%.js'],
     },
     {
       outputOptions: {
@@ -73,7 +73,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/complex',
       },
       url: '/complex/foo.js',
-      expected: '/foo.js',
+      expected: ['/foo.js'],
     },
     {
       outputOptions: {
@@ -81,7 +81,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: 'http://localhost:8080/',
       },
       url: '/0.19dc5d417382d73dd190.hot-update.js',
-      expected: '/0.19dc5d417382d73dd190.hot-update.js',
+      expected: ['/0.19dc5d417382d73dd190.hot-update.js'],
     },
     {
       outputOptions: {
@@ -89,7 +89,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: 'http://localhost:8080/',
       },
       url: '/bar.js',
-      expected: '/bar.js',
+      expected: ['/bar.js'],
     },
     {
       outputOptions: {
@@ -97,7 +97,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       url: '/test.html?foo=bar',
-      expected: '/test.html',
+      expected: ['/test.html'],
     },
     {
       outputOptions: {
@@ -105,7 +105,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       url: '/test.html?foo=bar#hash',
-      expected: '/test.html',
+      expected: ['/test.html'],
     },
     {
       outputOptions: {
@@ -113,7 +113,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       url: '/a.js',
-      expected: '/dist/a.js',
+      expected: ['/dist/a.js'],
     },
     {
       outputOptions: {
@@ -121,7 +121,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '',
       },
       url: '/b.js',
-      expected: '/b.js',
+      expected: ['/b.js'],
     },
     {
       outputOptions: {
@@ -129,7 +129,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '',
       },
       url: '/c.js',
-      expected: '/c.js',
+      expected: ['/c.js'],
     },
     {
       outputOptions: {
@@ -137,7 +137,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       url: '/more/complex/path.js',
-      expected: '/a/more/complex/path.js',
+      expected: ['/a/more/complex/path.js'],
     },
     {
       outputOptions: {
@@ -145,8 +145,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/complex',
       },
       url: '/more/complex/path.js',
-      // eslint-disable-next-line no-undefined
-      expected: undefined,
+      expected: [],
     },
     {
       // publicPath is not in url, so it should fail
@@ -155,8 +154,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       url: 'c.js',
-      // eslint-disable-next-line no-undefined
-      expected: undefined,
+      expected: [],
     },
     {
       outputOptions: {
@@ -164,7 +162,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/bar/',
       },
       url: '/bar/',
-      expected: '/foo',
+      expected: ['/foo'],
     },
     {
       outputOptions: {
@@ -172,8 +170,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: 'http://localhost/foo/',
       },
       url: '/bar/',
-      // eslint-disable-next-line no-undefined
-      expected: undefined,
+      expected: [],
     },
     {
       outputOptions: {
@@ -181,8 +178,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: 'http://localhost:8080/foo/',
       },
       url: '/bar/',
-      // eslint-disable-next-line no-undefined
-      expected: undefined,
+      expected: [],
     },
     {
       outputOptions: {
@@ -190,7 +186,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: 'http://localhost:8080/foo/',
       },
       url: 'http://localhost:8080/foo/index.html',
-      expected: '/index.html',
+      expected: ['/index.html'],
     },
     {
       outputOptions: {
@@ -198,7 +194,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '//localhost:8080/foo/',
       },
       url: '//localhost:8080/foo/index.html',
-      expected: '/index.html',
+      expected: ['/index.html'],
     },
     {
       outputOptions: {
@@ -206,8 +202,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: 'http://localhost:8080/foo/',
       },
       url: 'http://localhost:8080/bar/index.html',
-      // eslint-disable-next-line no-undefined
-      expected: undefined,
+      expected: [],
     },
     {
       outputOptions: {
@@ -215,7 +210,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/test/',
       },
       url: 'http://test.domain/test/sample.js',
-      expected: '/sample.js',
+      expected: ['/sample.js'],
     },
     {
       outputOptions: {
@@ -223,7 +218,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '//test.domain/protocol/relative/',
       },
       url: '/protocol/relative/sample.js',
-      expected: '/sample.js',
+      expected: ['/sample.js'],
     },
     {
       outputOptions: {
@@ -231,7 +226,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       url: '/pathname%20with%20spaces.js',
-      expected: '/pathname with spaces.js',
+      expected: ['/pathname with spaces.js'],
     },
     {
       outputOptions: {
@@ -239,7 +234,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       url: '/dirname%20with%20spaces/filename%20with%20spaces.js',
-      expected: '/dirname with spaces/filename with spaces.js',
+      expected: ['/dirname with spaces/filename with spaces.js'],
     },
     {
       outputOptions: {
@@ -247,7 +242,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       url: '/dirname%20with%20spaces/filename%20with%20spaces.js',
-      expected: '/dirname with spaces/filename with spaces.js',
+      expected: ['/dirname with spaces/filename with spaces.js'],
     },
     {
       outputOptions: {
@@ -255,7 +250,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/public/',
       },
       url: '/public/foobar/../foo.js',
-      expected: '/static/foo.js',
+      expected: ['/static/foo.js'],
     },
     {
       outputOptions: [
@@ -269,7 +264,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/js/sample.js',
-      expected: '/foo/sample.js',
+      expected: ['/foo/sample.js'],
     },
     {
       outputOptions: [
@@ -283,7 +278,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/js/sample.js',
-      expected: '/foo/sample.js',
+      expected: ['/foo/sample.js'],
     },
     {
       outputOptions: [
@@ -297,7 +292,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/css/sample.js',
-      expected: '/foo/sample.js',
+      expected: ['/foo/sample.js', '/bar/sample.js'],
     },
     {
       outputOptions: [
@@ -311,7 +306,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/css/sample.css',
-      expected: '/bar/sample.css',
+      expected: ['/bar/sample.css'],
     },
     {
       outputOptions: [
@@ -325,7 +320,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/css/sample.css',
-      expected: '/bar/sample.css',
+      expected: ['/bar/sample.css'],
     },
     {
       outputOptions: [
@@ -347,8 +342,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/five/sample.css',
-      // eslint-disable-next-line no-undefined
-      expected: undefined,
+      expected: [],
     },
     {
       outputOptions: [
@@ -362,8 +356,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/other/sample.txt',
-      // eslint-disable-next-line no-undefined
-      expected: undefined,
+      expected: [],
     },
     {
       outputOptions: [
@@ -377,8 +370,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/other/sample.txt',
-      // eslint-disable-next-line no-undefined
-      expected: undefined,
+      expected: [],
     },
     {
       outputOptions: [
@@ -391,7 +383,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/js/sample.js',
-      expected: '/foo/sample.js',
+      expected: ['/foo/sample.js', '/bar/js/sample.js'],
     },
     {
       outputOptions: [
@@ -405,7 +397,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/css/sample.css',
-      expected: '/bar/sample.css',
+      expected: ['/bar/sample.css', '/foo/css/sample.css'],
     },
     {
       outputOptions: [
@@ -419,7 +411,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/js/sample.js',
-      expected: '/sample.js',
+      expected: ['/sample.js'],
     },
     {
       outputOptions: [
@@ -433,7 +425,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/css/sample.css',
-      expected: '/sample.css',
+      expected: ['/sample.css'],
     },
     {
       outputOptions: [
@@ -447,7 +439,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/js/sample.js',
-      expected: '/foo/sample.js',
+      expected: ['/foo/sample.js'],
     },
     {
       outputOptions: [
@@ -461,7 +453,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/js/sample.js',
-      expected: '/foo/sample.js',
+      expected: ['/foo/sample.js'],
     },
     {
       outputOptions: [
@@ -475,7 +467,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/css/sample.css',
-      expected: '/bar/sample.css',
+      expected: ['/bar/sample.css'],
     },
     {
       outputOptions: [
@@ -489,7 +481,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/css/sample.css',
-      expected: '/bar/sample.css',
+      expected: ['/bar/sample.css'],
     },
     {
       outputOptions: [
@@ -503,8 +495,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/other/sample.txt',
-      // eslint-disable-next-line no-undefined
-      expected: undefined,
+      expected: [],
     },
     {
       outputOptions: [
@@ -518,8 +509,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/other/sample.txt',
-      // eslint-disable-next-line no-undefined
-      expected: undefined,
+      expected: [],
     },
     {
       outputOptions: [
@@ -533,8 +523,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/test/sample.txt',
-      // eslint-disable-next-line no-undefined
-      expected: undefined,
+      expected: [],
     },
     {
       outputOptions: [
@@ -548,8 +537,7 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/test/sample.txt',
-      // eslint-disable-next-line no-undefined
-      expected: undefined,
+      expected: [],
     },
     {
       outputOptions: {
@@ -557,7 +545,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       url: '/test/sample.txt',
-      expected: '/test/#leadinghash/test/sample.txt',
+      expected: ['/test/#leadinghash/test/sample.txt'],
     },
     {
       outputOptions: {
@@ -565,7 +553,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       url: '/folder-name-with-dots/mono-v6.x.x',
-      expected: '/folder-name-with-dots/mono-v6.x.x',
+      expected: ['/folder-name-with-dots/mono-v6.x.x'],
     },
     {
       outputOptions: {
@@ -573,8 +561,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       url: '%',
-      // eslint-disable-next-line no-undefined
-      expected: undefined,
+      expected: [],
     },
     {
       outputOptions: {
@@ -582,8 +569,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/',
       },
       url: '\uD800',
-      // eslint-disable-next-line no-undefined
-      expected: undefined,
+      expected: [],
     },
     {
       outputOptions: {
@@ -591,7 +577,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/foo/',
       },
       url: '/foo/\x46\x6F\x6F',
-      expected: '/bar/Foo',
+      expected: ['/bar/Foo'],
     },
     {
       outputOptions: {
@@ -599,8 +585,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/complex/',
       },
       url: 'https://test:malfor%5Med@test.example.com',
-      // eslint-disable-next-line no-undefined
-      expected: undefined,
+      expected: [],
     },
     {
       outputOptions: {
@@ -608,8 +593,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: 'https://test:malfor%5Med@test.example.com',
       },
       url: '/foo/bar',
-      // eslint-disable-next-line no-undefined
-      expected: undefined,
+      expected: [],
     },
 
     // Windows tests
@@ -620,7 +604,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/test',
       },
       url: '/test/windows.txt',
-      expected: 'c:\\foo\\windows.txt',
+      expected: ['c:\\foo\\windows.txt'],
     },
     // Tests for #284
     {
@@ -630,7 +614,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/test',
       },
       url: '/test/windows.txt',
-      expected: 'C:\\My%20Path\\wwwroot\\windows.txt',
+      expected: ['C:\\My%20Path\\wwwroot\\windows.txt'],
     },
     {
       condition: isWindows,
@@ -639,7 +623,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/test',
       },
       url: '/test/windows%202.txt',
-      expected: 'C:\\My%20Path\\wwwroot\\windows 2.txt',
+      expected: ['C:\\My%20Path\\wwwroot\\windows 2.txt'],
     },
     // Tests for #297
     {
@@ -649,7 +633,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/test',
       },
       url: '/test/windows.txt',
-      expected: 'C:\\My Path\\wwwroot\\windows.txt',
+      expected: ['C:\\My Path\\wwwroot\\windows.txt'],
     },
     {
       condition: isWindows,
@@ -658,7 +642,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/test',
       },
       url: '/test/windows%202.txt',
-      expected: 'C:\\My Path\\wwwroot\\windows 2.txt',
+      expected: ['C:\\My Path\\wwwroot\\windows 2.txt'],
     },
     // Tests for #284 & #297
     {
@@ -668,7 +652,7 @@ describe('GetFilenameFromUrl', () => {
         publicPath: '/windows%20test',
       },
       url: '/windows%20test/test%20%26%20test%20%26%20%2520.txt',
-      expected: 'C:\\My %20 Path\\wwwroot\\test & test & %20.txt',
+      expected: ['C:\\My %20 Path\\wwwroot\\test & test & %20.txt'],
     },
   ];
 

--- a/test/utils/getFilenameFromUrl.test.js
+++ b/test/utils/getFilenameFromUrl.test.js
@@ -86,30 +86,30 @@ describe('GetFilenameFromUrl', () => {
       url: '/complex/foo.js',
       expected: '/foo.js',
     },
-    {
-      outputOptions: {
-        path: '/',
-        publicPath: 'http://localhost:8081/complex/',
-      },
-      url: 'http://localhost:8080/complex/foo.js',
-      expected: false,
-    },
-    {
-      outputOptions: {
-        path: '/',
-        publicPath: 'http://localhost:8080/complex/',
-      },
-      url: 'https://localhost:8080/complex/foo.js',
-      expected: false,
-    },
-    {
-      outputOptions: {
-        path: '/',
-        publicPath: 'http://foo:pass@localhost:8080/complex/',
-      },
-      url: 'http://bar:pass@localhost:8080/complex/foo.js',
-      expected: false,
-    },
+    // {
+    //  outputOptions: {
+    //    path: '/',
+    //    publicPath: 'http://localhost:8081/complex/',
+    //  },
+    //  url: 'http://localhost:8080/complex/foo.js',
+    //  expected: false,
+    // },
+    // {
+    //  outputOptions: {
+    //    path: '/',
+    //    publicPath: 'http://localhost:8080/complex/',
+    //  },
+    //  url: 'https://localhost:8080/complex/foo.js',
+    //  expected: false,
+    // },
+    // {
+    //  outputOptions: {
+    //    path: '/',
+    //    publicPath: 'http://foo:pass@localhost:8080/complex/',
+    //  },
+    //  url: 'http://bar:pass@localhost:8080/complex/foo.js',
+    //  expected: false,
+    // },
     {
       outputOptions: {
         path: '/',
@@ -250,14 +250,14 @@ describe('GetFilenameFromUrl', () => {
       url: 'http://test.domain/test/sample.js',
       expected: '/sample.js',
     },
-    {
-      outputOptions: {
-        path: '/',
-        publicPath: 'http://other.domain/test/',
-      },
-      url: 'http://test.domain/test/sample.js',
-      expected: false,
-    },
+    // {
+    //  outputOptions: {
+    //    path: '/',
+    //    publicPath: 'http://other.domain/test/',
+    //  },
+    //  url: 'http://test.domain/test/sample.js',
+    //  expected: false,
+    // },
     {
       outputOptions: {
         path: '/',
@@ -324,6 +324,20 @@ describe('GetFilenameFromUrl', () => {
         },
       ],
       url: '/js/sample.js',
+      expected: '/foo/sample.js',
+    },
+    {
+      outputOptions: [
+        {
+          path: '/foo',
+          publicPath: 'http://localhost/css/',
+        },
+        {
+          path: '/bar',
+          publicPath: 'http://localhost/css/',
+        },
+      ],
+      url: '/css/sample.js',
       expected: '/foo/sample.js',
     },
     {

--- a/test/utils/getFilenameFromUrl.test.js
+++ b/test/utils/getFilenameFromUrl.test.js
@@ -28,37 +28,20 @@ function getStatsMock(outputOptions) {
 describe('GetFilenameFromUrl', () => {
   const tests = [
     {
-      outputOptions: {},
-      url: '/foo.js',
-      expected: '/foo.js',
-    },
-    {
       outputOptions: {
-        // eslint-disable-next-line no-undefined
-        path: undefined,
-        // eslint-disable-next-line no-undefined
-        publicPath: undefined,
+        path: '/',
+        publicPath: '',
       },
       url: '/foo.js',
       expected: '/foo.js',
-    },
-    {
-      outputOptions: {
-        // eslint-disable-next-line no-undefined
-        path: undefined,
-        // eslint-disable-next-line no-undefined
-        publicPath: undefined,
-      },
-      url: '/complex/foo.js',
-      expected: '/complex/foo.js',
     },
     {
       outputOptions: {
         path: '/',
-        publicPath: '/',
+        publicPath: '',
       },
-      url: '/foo.js',
-      expected: '/foo.js',
+      url: '/complex/foo.js',
+      expected: '/complex/foo.js',
     },
     {
       // Express encodes the URI component, so we do the same
@@ -86,30 +69,6 @@ describe('GetFilenameFromUrl', () => {
       url: '/complex/foo.js',
       expected: '/foo.js',
     },
-    // {
-    //  outputOptions: {
-    //    path: '/',
-    //    publicPath: 'http://localhost:8081/complex/',
-    //  },
-    //  url: 'http://localhost:8080/complex/foo.js',
-    //  expected: false,
-    // },
-    // {
-    //  outputOptions: {
-    //    path: '/',
-    //    publicPath: 'http://localhost:8080/complex/',
-    //  },
-    //  url: 'https://localhost:8080/complex/foo.js',
-    //  expected: false,
-    // },
-    // {
-    //  outputOptions: {
-    //    path: '/',
-    //    publicPath: 'http://foo:pass@localhost:8080/complex/',
-    //  },
-    //  url: 'http://bar:pass@localhost:8080/complex/foo.js',
-    //  expected: false,
-    // },
     {
       outputOptions: {
         path: '/',
@@ -153,18 +112,15 @@ describe('GetFilenameFromUrl', () => {
     {
       outputOptions: {
         path: '/',
-        // eslint-disable-next-line no-undefined
-        publicPath: undefined,
+        publicPath: '',
       },
       url: '/b.js',
       expected: '/b.js',
     },
     {
       outputOptions: {
-        // eslint-disable-next-line no-undefined
-        path: undefined,
-        // eslint-disable-next-line no-undefined
-        publicPath: undefined,
+        path: '/',
+        publicPath: '',
       },
       url: '/c.js',
       expected: '/c.js',
@@ -250,14 +206,6 @@ describe('GetFilenameFromUrl', () => {
       url: 'http://test.domain/test/sample.js',
       expected: '/sample.js',
     },
-    // {
-    //  outputOptions: {
-    //    path: '/',
-    //    publicPath: 'http://other.domain/test/',
-    //  },
-    //  url: 'http://test.domain/test/sample.js',
-    //  expected: false,
-    // },
     {
       outputOptions: {
         path: '/',
@@ -371,6 +319,28 @@ describe('GetFilenameFromUrl', () => {
     {
       outputOptions: [
         {
+          path: '/one',
+          publicPath: 'http://localhost/one/',
+        },
+        {
+          path: '/two',
+          publicPath: 'http://localhost/two/',
+        },
+        {
+          path: '/three',
+          publicPath: 'http://localhost/three/',
+        },
+        {
+          path: '/four',
+          publicPath: 'http://localhost/four/',
+        },
+      ],
+      url: '/five/sample.css',
+      expected: false,
+    },
+    {
+      outputOptions: [
+        {
           path: '/foo',
           publicPath: '/js/',
         },
@@ -413,6 +383,7 @@ describe('GetFilenameFromUrl', () => {
       outputOptions: [
         {
           path: '/foo',
+          publicPath: '',
         },
         {
           path: '/bar',
@@ -425,6 +396,7 @@ describe('GetFilenameFromUrl', () => {
     {
       outputOptions: [
         {
+          path: '/',
           publicPath: '/js/',
         },
         {
@@ -442,6 +414,7 @@ describe('GetFilenameFromUrl', () => {
           publicPath: '/js/',
         },
         {
+          path: '/',
           publicPath: '/css/',
         },
       ],

--- a/test/utils/getFilenameFromUrl.test.js
+++ b/test/utils/getFilenameFromUrl.test.js
@@ -217,6 +217,14 @@ describe('GetFilenameFromUrl', () => {
       expected: '/dirname with spaces/filename with spaces.js',
     },
     {
+      outputOptions: {
+        path: '/static/',
+        publicPath: '/public/',
+      },
+      url: '/public/foobar/../foo.js',
+      expected: '/static/foo.js',
+    },
+    {
       url: '/js/sample.js',
       outputOptions: [
         {
@@ -481,72 +489,72 @@ describe('GetFilenameFromUrl', () => {
       },
       expected: '/folder-name-with-dots/mono-v6.x.x',
     },
+    // Windows tests
+    {
+      condition: isWindows,
+      url: '/test/windows.txt',
+      outputOptions: {
+        path: 'c:\\foo',
+        publicPath: '/test',
+      },
+      expected: 'c:\\foo\\windows.txt',
+    },
+    // Tests for #284
+    {
+      condition: isWindows,
+      url: '/test/windows.txt',
+      outputOptions: {
+        path: 'C:\\My%20Path\\wwwroot',
+        publicPath: '/test',
+      },
+      expected: 'C:\\My%20Path\\wwwroot\\windows.txt',
+    },
+    {
+      condition: isWindows,
+      url: '/test/windows%202.txt',
+      outputOptions: {
+        path: 'C:\\My%20Path\\wwwroot',
+        publicPath: '/test',
+      },
+      expected: 'C:\\My%20Path\\wwwroot\\windows 2.txt',
+    },
+    // Tests for #297
+    {
+      condition: isWindows,
+      url: '/test/windows.txt',
+      outputOptions: {
+        path: 'C:\\My Path\\wwwroot',
+        publicPath: '/test',
+      },
+      expected: 'C:\\My Path\\wwwroot\\windows.txt',
+    },
+    {
+      condition: isWindows,
+      url: '/test/windows%202.txt',
+      outputOptions: {
+        path: 'C:\\My Path\\wwwroot',
+        publicPath: '/test',
+      },
+      expected: 'C:\\My Path\\wwwroot\\windows 2.txt',
+    },
+    // Tests for #284 & #297
+    {
+      condition: isWindows,
+      url: '/windows%20test/test%20%26%20test%20%26%20%2520.txt',
+      outputOptions: {
+        path: 'C:\\My %20 Path\\wwwroot',
+        publicPath: '/windows%20test',
+      },
+      expected: 'C:\\My %20 Path\\wwwroot\\test & test & %20.txt',
+    },
   ];
 
   for (const test of tests) {
-    it(`should process ${test.url} -> ${test.expected}`, () => {
-      testUrl(test);
-    });
-  }
-
-  // Explicit Tests for Microsoft Windows
-  if (isWindows) {
-    const windowsTests = [
-      {
-        url: '/test/windows.txt',
-        outputOptions: {
-          path: 'c:\\foo',
-          publicPath: '/test',
-        },
-        expected: 'c:\\foo/windows.txt',
-      },
-      // Tests for #284
-      {
-        url: '/test/windows.txt',
-        outputOptions: {
-          path: 'C:\\My%20Path\\wwwroot',
-          publicPath: '/test',
-        },
-        expected: 'C:\\My%20Path\\wwwroot/windows.txt',
-      },
-      {
-        url: '/test/windows%202.txt',
-        outputOptions: {
-          path: 'C:\\My%20Path\\wwwroot',
-          publicPath: '/test',
-        },
-        expected: 'C:\\My%20Path\\wwwroot/windows 2.txt',
-      },
-      // Tests for #297
-      {
-        url: '/test/windows.txt',
-        outputOptions: {
-          path: 'C:\\My Path\\wwwroot',
-          publicPath: '/test',
-        },
-        expected: 'C:\\My Path\\wwwroot/windows.txt',
-      },
-      {
-        url: '/test/windows%202.txt',
-        outputOptions: {
-          path: 'C:\\My Path\\wwwroot',
-          publicPath: '/test',
-        },
-        expected: 'C:\\My Path\\wwwroot/windows 2.txt',
-      },
-      // Tests for #284 & #297
-      {
-        url: '/windows%20test/test%20%26%20test%20%26%20%2520.txt',
-        outputOptions: {
-          path: 'C:\\My %20 Path\\wwwroot',
-          publicPath: '/windows%20test',
-        },
-        expected: 'C:\\My %20 Path\\wwwroot/test & test & %20.txt',
-      },
-    ];
-
-    for (const test of windowsTests) {
-      it(`windows: should process ${test.url} -> ${test.expected}`, () => {
+    if (
+      typeof test.condition === 'undefined' ||
+      (typeof test.condition !== 'undefined' && test.condition)
+    ) {
+      it(`should process ${test.url} -> ${test.expected}`, () => {
         testUrl(test);
       });
     }

--- a/test/utils/getPossibleFilePaths.test.js
+++ b/test/utils/getPossibleFilePaths.test.js
@@ -1,4 +1,4 @@
-import getFilenameFromUrl from '../../src/utils/getFilenameFromUrl';
+import getFilenameFromUrl from '../../src/utils/getPossibleFilePaths';
 
 const isWindows = process.platform === 'win32';
 
@@ -8,8 +8,8 @@ function testUrl(test) {
 
   let { expected } = test;
 
-  if (typeof expected !== 'undefined' && isWindows) {
-    expected = expected.replace(/\//g, '\\');
+  if (isWindows) {
+    expected = expected.map((item) => item.replace(/\//g, '\\'));
   }
 
   expect(getFilenameFromUrl(context, test.url, stats)).toEqual(expected);


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

There was a lot of wrong logic:
- `request.url` is always `/path/to/file.js?foo=bar#hash`, so it is unnecessary to check on `host`
- we should avoid check on the `host` because it is middleware, we don't know what hosts a developer what to use, it should be done on application side (we already do it in webpack-dev-server)
- memorize the `parse`, no need parse multiple times same urls
- remove invalid tests
- refactor tests
- new tests
- when you use multi-compiler mode you can use same "publicPath" but difference "output.path" and versa vise, so we need return array of possible files, also some a child compiler can not have "publicPath"
- rename to `getPossibleFilePaths`

### Breaking Changes

Yes, there are a lot of fixes + remove `getPossibleFilePaths` from API, it is doesn't have sense to do public, because we can't use it before compilation, after compilation you can get paths from stats

### Additional Info

No