### PR TITLE
feat: add webpack bot for trigger documentation issue

### DIFF
--- a/open-bot.yaml
+++ b/open-bot.yaml
@@ -1,0 +1,41 @@
+bot: "webpack-bot"
+rules:
+  # Add action actions box to each pull request
+  - filters:
+      pull_request: true
+      open: true
+      not:
+        comment:
+          matching: admin-actions
+          author: webpack-bot
+    actions:
+      comment:
+        identifier: admin-actions
+        message: |-
+          *For maintainers only:*
+          * [ ] <!-- document --> This needs to be documented (issue in webpack/webpack.js.org will be filed when merged)
+  # When a pull request need to be documented, create an issue in webpack/webpack.js.org when merged
+  - filters:
+      pull_request:
+        merged: true
+      comment:
+        author: webpack-bot
+        matching: "\\* \\[x\\] <!-- document -->"
+      not:
+        comment_1:
+          author: webpack-bot
+          matching: admin-action-document-executed
+    actions:
+      new_issue:
+        target: webpack/webpack.js.org
+        title: "Document webpack change: {{{pull_request.title}}}"
+        body: |-
+          <!-- documentation request from webpack/webpack -->
+          *A pull request by @{{pull_request.user.login}} was merged and maintainers requested a documentation change.*
+          See pull request: {{{pull_request.html_url}}}
+          ---
+          {{{pull_request.body}}}
+      comment:
+        identifier: admin-action-document-executed
+        message: |-
+          I've created an issue to document this in webpack/webpack.js.org.


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
Checking the documentation checkbox would create an issue in documentation repo to be in sync with the changed
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes
None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
Would ease out a little bit of work :) 