### PR TITLE
fix(middleware): change how mime type option is handled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,6 @@ export default function wdm(compiler, options = {}) {
 
     mime.types = { ...types, ...mimeTypes };
   }
-  console.log(mime.types);
 
   const context = {
     state: false,

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,8 @@ export default function wdm(compiler, options = {}) {
   if (mimeTypes) {
     const { types } = mime;
 
+    // mimeTypes from user provided options should take priority
+    // over existing, known types
     mime.types = { ...types, ...mimeTypes };
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,9 @@ export default function wdm(compiler, options = {}) {
   if (mimeTypes) {
     const { types } = mime;
 
-    mime.types = { ...mimeTypes, ...types };
+    mime.types = { ...types, ...mimeTypes };
   }
+  console.log(mime.types);
 
   const context = {
     state: false,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -49,15 +49,9 @@ export default function wrapper(context) {
         return;
       }
 
-      try {
-        content = context.outputFileSystem.readFileSync(filename);
-      } catch (_ignoreError) {
-        await goNext();
-        return;
-      }
-
-      // Buffer
-      content = handleRangeHeaders(content, req, res);
+      // Content-Type and headers need to be set before checking if
+      // the file is in the outputFileSystem, as these things should be
+      // applied to all files that are being served
 
       if (!res.get('Content-Type')) {
         // content-type name(like application/javascript; charset=utf-8) or false
@@ -73,6 +67,16 @@ export default function wrapper(context) {
           res.set(name, headers[name]);
         }
       }
+
+      try {
+        content = context.outputFileSystem.readFileSync(filename);
+      } catch (_ignoreError) {
+        await goNext();
+        return;
+      }
+
+      // Buffer
+      content = handleRangeHeaders(content, req, res);
 
       // send Buffer
       res.send(content);

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -1990,7 +1990,7 @@ describe('middleware', () => {
 
       afterAll(close);
 
-      it('should return the "200" code for the "GET" request to "file.html"', (done) => {
+      it('should return the "200" code for the "GET" request to "file.phtml"', (done) => {
         request(app)
           .get('/file.phtml')
           .expect('Content-Type', 'application/octet-stream')
@@ -2031,11 +2031,52 @@ describe('middleware', () => {
 
       afterAll(close);
 
-      it('should return the "200" code for the "GET" request "file.html"', (done) => {
+      it('should return the "200" code for the "GET" request "file.phtml"', (done) => {
         request(app)
           .get('/file.phtml')
           .expect('Content-Type', 'text/html; charset=utf-8')
           .expect(200, 'welcome', done);
+      });
+    });
+
+    describe('should override value for "Content-Type" header for known MIME type', () => {
+      beforeAll((done) => {
+        const outputPath = path.resolve(__dirname, './outputs/basic');
+        const compiler = getCompiler({
+          ...webpackConfig,
+          output: {
+            filename: 'bundle.js',
+            path: outputPath,
+          },
+        });
+
+        instance = middleware(compiler, {
+          mimeTypes: {
+            jpg: 'application/octet-stream',
+          },
+        });
+
+        app = express();
+        app.use(instance);
+
+        listen = listenShorthand(done);
+
+        instance.context.outputFileSystem.mkdirSync(outputPath, {
+          recursive: true,
+        });
+        instance.context.outputFileSystem.writeFileSync(
+          path.resolve(outputPath, 'file.jpg'),
+          'welcome'
+        );
+      });
+
+      afterAll(close);
+
+      it('should return the "200" code for the "GET" request "file.jpg"', (done) => {
+        request(app)
+          .get('/file.jpg')
+          .expect('Content-Type', 'application/octet-stream')
+          .expect(200, done);
       });
     });
   });


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

I think that the `mimeType` option should take priority over existing, known mime types. Otherwise, specifying a `mimeType` for something like html or js will have no effect.

### Breaking Changes

Change of mimeType option priority with existing mime types

### Additional Info
