### PR TITLE
fix(middleware): switch headers and mime types handling back after file check

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -49,9 +49,12 @@ export default function wrapper(context) {
         return;
       }
 
-      // Content-Type and headers need to be set before checking if
-      // the file is in the outputFileSystem, as these things should be
-      // applied to all files that are being served
+      try {
+        content = context.outputFileSystem.readFileSync(filename);
+      } catch (_ignoreError) {
+        await goNext();
+        return;
+      }
 
       if (!res.get('Content-Type')) {
         // content-type name(like application/javascript; charset=utf-8) or false
@@ -66,13 +69,6 @@ export default function wrapper(context) {
         for (const name of Object.keys(headers)) {
           res.set(name, headers[name]);
         }
-      }
-
-      try {
-        content = context.outputFileSystem.readFileSync(filename);
-      } catch (_ignoreError) {
-        await goNext();
-        return;
       }
 
       // Buffer

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -2080,7 +2080,7 @@ describe('middleware', () => {
       });
     });
 
-    describe('should set "Content-Type" header for route not from outputFileSystem', () => {
+    describe('should not set "Content-Type" header for route not from outputFileSystem', () => {
       beforeAll((done) => {
         const outputPath = path.resolve(__dirname, './outputs/basic');
         const compiler = getCompiler({
@@ -2109,10 +2109,10 @@ describe('middleware', () => {
 
       afterAll(close);
 
-      it('should return the "200" code for the "GET" request "file.jpg"', (done) => {
+      it('should return the "200" code for the "GET" request "file.jpg" with default content type', (done) => {
         request(app)
           .get('/file.jpg')
-          .expect('Content-Type', /application\/octet-stream/)
+          .expect('Content-Type', /text\/html/)
           .expect(200, done);
       });
     });
@@ -2741,15 +2741,15 @@ describe('middleware', () => {
         .expect(200, done);
     });
 
-    it('should return the "200" code for the "GET" request to path not in outputFileSystem and return headers', (done) => {
+    it('should return the "200" code for the "GET" request to path not in outputFileSystem but not return headers', async () => {
       app.get('/file.jpg', (req, res) => {
         res.send('welcome');
       });
-      request(app)
-        .get('/file.jpg')
-        .expect('X-nonsense-1', 'yes')
-        .expect('X-nonsense-2', 'no')
-        .expect(200, done);
+
+      const res = await request(app).get('/file.jpg');
+      expect(res.statusCode).toEqual(200);
+      expect(res.headers['X-nonsense-1']).toBeUndefined();
+      expect(res.headers['X-nonsense-2']).toBeUndefined();
     });
   });
 


### PR DESCRIPTION

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Switch headers and mimeType handling back after it is checked whether the file is in outputFileSystem

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
