### PR TITLE
fix(output-file-system): change from backslash to forward slash in join

### DIFF
--- a/src/utils/setupOutputFileSystem.js
+++ b/src/utils/setupOutputFileSystem.js
@@ -27,7 +27,9 @@ export default function setupOutputFileSystem(context) {
   } else {
     outputFileSystem = createFsFromVolume(new Volume());
     // TODO: remove when we drop webpack@4 support
-    outputFileSystem.join = path.join.bind(path);
+    const newPath = Object.assign({}, path);
+    newPath.join = (...files) => path.join(...files).replace(/[\\/]+/g, '/');
+    outputFileSystem.join = newPath.join.bind(newPath);
   }
 
   const compilers = context.compiler.compilers || [context.compiler];


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

In `webpack`, if there is a `join` method of `outputFileSystem`, use the `join` method. However, if you use the `join` method in `windows os`, a problem occurs when the path is relative.
Ex)
before `join`:
`/app/js`
after `join`:
`\app\join`

If it changes as above, the following error occurs.

```
D:\foo\node_modules\webpack\lib\util\fs.js:141
                throw new Error(
                ^

Error: \js\app.js is neither a posix nor a windows path, and there is no 'dirname' method defined in the file system
    at dirname (D:\foo\node_modules\webpack\lib\util\fs.js:141:9)
    at D:\foo\node_modules\webpack\lib\Compiler.js:790:19
    at arrayIterator (D:\foo\node_modules\neo-async\async.js:3467:9)
    at timesSync (D:\foo\node_modules\neo-async\async.js:2297:7)
    at Object.eachLimit (D:\foo\node_modules\neo-async\async.js:3463:5)
    at emitFiles (D:\foo\node_modules\webpack\lib\Compiler.js:536:13)
    at D:\foo\node_modules\webpack\lib\util\fs.js:182:5
    at Immediate.<anonymous> (D:\foo\node_modules\memfs\lib\volume.js:684:17)
    at processImmediate (internal/timers.js:461:21)
```

This PR solves that problem.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

The `join` method of `outputFileSystem` returns all backslashes replaced with slashes.

### Additional Info
https://github.com/webpack/webpack/blob/master/lib/util/fs.js#L133-L145