### PR TITLE
fix: skip content-type header on unknown types

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -65,16 +65,17 @@ export default function wrapper(context) {
         // content-type name(like application/javascript; charset=utf-8) or false
         const contentType = mime.contentType(path.extname(filename));
 
-        // Express API
-        if (res.set && contentType) {
-          res.set('Content-Type', contentType);
-        }
-        // Node.js API
-        else {
-          res.setHeader(
-            'Content-Type',
-            contentType || 'application/octet-stream'
-          );
+        // Only set content-type header if media type is known
+        // https://tools.ietf.org/html/rfc7231#section-3.1.1.5
+        if (contentType) {
+          // Express API
+          if (res.set) {
+            res.set('Content-Type', contentType);
+          }
+          // Node.js API
+          else {
+            res.setHeader('Content-Type', contentType);
+          }
         }
       }
 


### PR DESCRIPTION
Fixes #354

* Only set 'Content-Type' header if mime type is known.
* Remove testing for 'Content-Type' of unknown types.
* Do not test against `application/octet-stream'.

Unknown media types should have content-type blank. Because
frameworks handle Content-Types differently, it is not possible to
standardize testing at the moment. Tests against
`application/octet-stream` can create false positives with Express
because of this.

https://tools.ietf.org/html/rfc7231#section-3.1.1.5
https://github.com/broofa/mime/issues/139

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

Unknown mime types (no extension or unknown extension) no longer produce a `Content-Type` with Connect/NodeJS API.

### Additional Info

https://tools.ietf.org/html/rfc7231#section-3.1.1.5
https://github.com/broofa/mime/issues/139

