### PR TITLE
fix: account for undefined statsOptions

### DIFF
--- a/src/utils/setupHooks.js
+++ b/src/utils/setupHooks.js
@@ -67,7 +67,7 @@ export default function setupHooks(context) {
       } else if (
         statsOptions &&
         (typeof statsOptions.colors === 'undefined' ||
-        typeof statsOptions === 'string')
+          typeof statsOptions === 'string')
       ) {
         if (statsForWebpack4) {
           statsOptions = webpack.Stats.presetToOptions(statsOptions);

--- a/src/utils/setupHooks.js
+++ b/src/utils/setupHooks.js
@@ -65,8 +65,9 @@ export default function setupHooks(context) {
           }
         );
       } else if (
-        typeof statsOptions.colors === 'undefined' ||
-        typeof statsOptions === 'string'
+        statsOptions &&
+        (typeof statsOptions.colors === 'undefined' ||
+        typeof statsOptions === 'string')
       ) {
         if (statsForWebpack4) {
           statsOptions = webpack.Stats.presetToOptions(statsOptions);


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

I was getting `Cannot read property 'colors' of undefined` at this point in the built dev-middleware, which makes sense as it is [possible for it to be undefined](https://github.com/webpack/webpack-dev-middleware/blob/2402af9232062cc9ed1c22fef7046511d6b29b39/src/utils/setupHooks.js#L45).

Reproduction: https://codesandbox.io/s/recursing-keller-b8g1s?file=/nuxt.config.js

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
