### PR TITLE
fix: use webpack logger to print stats

### DIFF
--- a/src/utils/setupHooks.js
+++ b/src/utils/setupHooks.js
@@ -88,8 +88,7 @@ export default function setupHooks(context) {
 
       // Avoid extra empty line when `stats: 'none'`
       if (printedStats) {
-        // eslint-disable-next-line no-console
-        console.log(printedStats);
+        logger.log(printedStats);
       }
 
       // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**

### Motivation / Use-Case

The latest `webpack-dev-middleware` changed from logger to console.log for printing stats, it breaks usage that someone is using customized webpack logger by `infrastructureLog` hook or `infrastructureLogging` config.

I've tested locally with logger.log, it works fine with coloured stats log, I'm not sure if using console.log is intentional or not, if there is any valid reason, please feel free to let me know.