### PR TITLE
replace mem with better, smaller alternative

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "colorette": "^1.2.2",
-        "mem": "^8.1.1",
+        "fast-memoize": "^2.5.2",
         "memfs": "^3.2.2",
         "mime-types": "^2.1.31",
         "range-parser": "^1.2.1",
@@ -6818,6 +6818,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fast-memoize": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
@@ -11259,17 +11264,6 @@
         "tmpl": "1.0.x"
       }
     },
-    "node_modules/map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dependencies": {
-        "p-defer": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -11312,21 +11306,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/mem": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
-      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
-      "dependencies": {
-        "map-age-cleaner": "^0.1.3",
-        "mimic-fn": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/mem?sponsor=1"
       }
     },
     "node_modules/memfs": {
@@ -11636,14 +11615,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/mimic-fn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/min-indent": {
@@ -12231,14 +12202,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/p-each-series": {
@@ -20709,6 +20672,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-memoize": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
+    },
     "fast-safe-stringify": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
@@ -24031,14 +23999,6 @@
         "tmpl": "1.0.x"
       }
     },
-    "map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "requires": {
-        "p-defer": "^1.0.0"
-      }
-    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -24067,15 +24027,6 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
-    },
-    "mem": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
-      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
-      "requires": {
-        "map-age-cleaner": "^0.1.3",
-        "mimic-fn": "^3.1.0"
-      }
     },
     "memfs": {
       "version": "3.2.2",
@@ -24312,11 +24263,6 @@
       "requires": {
         "mime-db": "1.48.0"
       }
-    },
-    "mimic-fn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="
     },
     "min-indent": {
       "version": "1.0.1",
@@ -24777,11 +24723,6 @@
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
       }
-    },
-    "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
     },
     "p-each-series": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "license": "MIT",
       "dependencies": {
         "colorette": "^1.2.2",
-        "fast-memoize": "^2.5.2",
         "memfs": "^3.2.2",
         "mime-types": "^2.1.31",
         "range-parser": "^1.2.1",
@@ -6817,11 +6816,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "node_modules/fast-memoize": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
-      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.0.7",
@@ -20671,11 +20665,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "fast-memoize": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
-      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
     },
     "fast-safe-stringify": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "colorette": "^1.2.2",
-    "mem": "^8.1.1",
+    "fast-memoize": "^2.5.2",
     "memfs": "^3.2.2",
     "mime-types": "^2.1.31",
     "range-parser": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "colorette": "^1.2.2",
-    "fast-memoize": "^2.5.2",
     "memfs": "^3.2.2",
     "mime-types": "^2.1.31",
     "range-parser": "^1.2.1",

--- a/src/utils/getFilenameFromUrl.js
+++ b/src/utils/getFilenameFromUrl.js
@@ -1,12 +1,19 @@
 import path from "path";
-import { parse } from "url";
+import { URL } from "url";
 import querystring from "querystring";
-
-import memoize from "fast-memoize";
 
 import getPaths from "./getPaths";
 
-const memoizedParse = memoize(parse);
+const urlCache = new Map();
+const parseUrl = (url) => {
+  if (urlCache.has(url)) {
+    return urlCache.get(url);
+  }
+
+  const parsed = new URL(url, "http://localhost/");
+  urlCache.set(url, parsed);
+  return parsed;
+};
 
 export default function getFilenameFromUrl(context, url) {
   const { options } = context;
@@ -17,7 +24,7 @@ export default function getFilenameFromUrl(context, url) {
 
   try {
     // The `url` property of the `request` is contains only  `pathname`, `search` and `hash`
-    urlObject = memoizedParse(url, false, true);
+    urlObject = parseUrl(url);
   } catch (_ignoreError) {
     return;
   }
@@ -27,10 +34,8 @@ export default function getFilenameFromUrl(context, url) {
     let publicPathObject;
 
     try {
-      publicPathObject = memoizedParse(
-        publicPath !== "auto" && publicPath ? publicPath : "/",
-        false,
-        true
+      publicPathObject = parseUrl(
+        publicPath !== "auto" && publicPath ? publicPath : "/"
       );
     } catch (_ignoreError) {
       // eslint-disable-next-line no-continue

--- a/src/utils/getFilenameFromUrl.js
+++ b/src/utils/getFilenameFromUrl.js
@@ -2,11 +2,11 @@ import path from "path";
 import { parse } from "url";
 import querystring from "querystring";
 
-import mem from "mem";
+import memoize from "fast-memoize";
 
 import getPaths from "./getPaths";
 
-const memoizedParse = mem(parse);
+const memoizedParse = memoize(parse);
 
 export default function getFilenameFromUrl(context, url) {
   const { options } = context;

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -300,7 +300,7 @@ describe.each([
             output: {
               filename: "bundle.js",
               path: outputPath,
-              publicPath: "https://test:malfor%5Med@test.example.com",
+              publicPath: "https://malformed:test.example.com",
             },
           });
 


### PR DESCRIPTION
This PR contains a:

- [x] **metadata update**

I suppose its "metadata", manifest updates.

### Motivation / Use-Case

mem pulls in 3-4 deep of dependencies for something we can achieve with a single file of code.

this just drops it for a more sensible, dependency-free package that does the same job and does it faster too.