### PR TITLE
feat: don't read full file if range header is present

### DIFF
--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -231,23 +231,43 @@ describe.each([
         });
 
         it('should return the "206" code for the "GET" request with the valid range header', (done) => {
+          const fileData = instance.context.outputFileSystem.readFileSync(
+            path.resolve(outputPath, "bundle.js"),
+            "utf8"
+          );
           request(app)
             .get("/bundle.js")
             .set("Range", "bytes=3000-3500")
             .expect("Content-Length", "501")
             .expect("Content-Range", `bytes 3000-3500/${codeLength}`)
-            .expect(206, done);
+            .expect(206)
+            .then((response) => {
+              expect(response.text).toBe(fileData.substr(3000, 501));
+              expect(response.text.length).toBe(501);
+              done();
+            });
         });
 
         it('should return the "200" code for the "GET" request with malformed range header which is ignored', (done) => {
-          request(app).get("/bundle.js").set("Range", "abc").expect(200, done);
+          request(app)
+            .get("/bundle.js")
+            .set("Range", "abc")
+            .expect(200)
+            .then((response) => {
+              expect(response.text.length).toBe(codeLength);
+              done();
+            });
         });
 
         it('should return the "200" code for the "GET" request with multiple range header which is ignored', (done) => {
           request(app)
             .get("/bundle.js")
             .set("Range", "bytes=3000-3100,3200-3300")
-            .expect(200, done);
+            .expect(200)
+            .then((response) => {
+              expect(response.text.length).toBe(codeLength);
+              done();
+            });
         });
 
         it('should return the "404" code for the "GET" request with to the non-public path', (done) => {

--- a/test/utils/__snapshots__/handleRangeHeaders.test.js.snap.webpack4
+++ b/test/utils/__snapshots__/handleRangeHeaders.test.js.snap.webpack4
@@ -17,7 +17,7 @@ Array [
 ]
 `;
 
-exports[`handleRangeHeaders should handle multiple ranges 1`] = `
+exports[`handleRangeHeaders should handle multiple ranges by sending a regular response 1`] = `
 Array [
   Array [
     "A Range header with multiple ranges was provided. Multiple ranges are not supported, so a regular response will be sent for this request.",
@@ -25,7 +25,7 @@ Array [
 ]
 `;
 
-exports[`handleRangeHeaders should handle multiple ranges 2`] = `
+exports[`handleRangeHeaders should handle multiple ranges by sending a regular response 2`] = `
 Array [
   Array [
     "Accept-Ranges",

--- a/test/utils/__snapshots__/handleRangeHeaders.test.js.snap.webpack5
+++ b/test/utils/__snapshots__/handleRangeHeaders.test.js.snap.webpack5
@@ -17,7 +17,7 @@ Array [
 ]
 `;
 
-exports[`handleRangeHeaders should handle multiple ranges 1`] = `
+exports[`handleRangeHeaders should handle multiple ranges by sending a regular response 1`] = `
 Array [
   Array [
     "A Range header with multiple ranges was provided. Multiple ranges are not supported, so a regular response will be sent for this request.",
@@ -25,7 +25,7 @@ Array [
 ]
 `;
 
-exports[`handleRangeHeaders should handle multiple ranges 2`] = `
+exports[`handleRangeHeaders should handle multiple ranges by sending a regular response 2`] = `
 Array [
   Array [
     "Accept-Ranges",

--- a/test/utils/handleRangeHeaders.test.js
+++ b/test/utils/handleRangeHeaders.test.js
@@ -29,8 +29,8 @@ describe("handleRangeHeaders", () => {
       },
     };
 
-    const contentRes = handleRangeHeaders(context, content, req, res);
-    expect(contentRes).toEqual("bcde");
+    const ranges = handleRangeHeaders(context, content.length, req, res);
+    expect(ranges).toEqual({ start: 1, end: 4 });
     expect(res.statusCode).toEqual(206);
     expect(res.set.mock.calls).toMatchSnapshot();
   });
@@ -53,8 +53,8 @@ describe("handleRangeHeaders", () => {
       },
     };
 
-    const contentRes = handleRangeHeaders(context, content, req, res);
-    expect(contentRes).toEqual("abcdef");
+    const ranges = handleRangeHeaders(context, content, req, res);
+    expect(ranges).toEqual(null);
     expect(context.logger.error.mock.calls).toMatchSnapshot();
     expect(res.statusCode).toBeUndefined();
     expect(res.set.mock.calls).toMatchSnapshot();
@@ -78,13 +78,13 @@ describe("handleRangeHeaders", () => {
       },
     };
 
-    const contentRes = handleRangeHeaders(context, content, req, res);
-    expect(contentRes).toEqual("abcdef");
+    const ranges = handleRangeHeaders(context, content.length, req, res);
+    expect(ranges).toEqual(null);
     expect(res.statusCode).toEqual(416);
     expect(res.set.mock.calls).toMatchSnapshot();
   });
 
-  it("should handle multiple ranges", () => {
+  it("should handle multiple ranges by sending a regular response", () => {
     const content = "abcdef";
     const req = {
       headers: {
@@ -102,8 +102,8 @@ describe("handleRangeHeaders", () => {
       },
     };
 
-    const contentRes = handleRangeHeaders(context, content, req, res);
-    expect(contentRes).toEqual("abcdef");
+    const ranges = handleRangeHeaders(context, content.length, req, res);
+    expect(ranges).toEqual(null);
     expect(context.logger.error.mock.calls).toMatchSnapshot();
     expect(res.statusCode).toBeUndefined();
     expect(res.set.mock.calls).toMatchSnapshot();


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

I am reading in a 2GB file for [Remotion](https://remotion.dev). This is a framework for making videos in React, and the end product is not shipped to a website, but written to an MP4 file. Therefore it's not a problem that we import these large files in Webpack.

However, when the browser is loading a video, and we seek forward, then a range header is sent to Webpack Dev Server. Unfortunately it is slow, because WDS is still loading the full file. I adapted the logic from `serve-handler` instead so instead of reading the full 2GB file synchronously, it uses a Read Stream.

### Breaking Changes

No breaking changes.
