### PR TITLE
Don't hardcode "range" in getHeaderFromResponse

### DIFF
--- a/src/utils/compatibleAPI.js
+++ b/src/utils/compatibleAPI.js
@@ -40,7 +40,7 @@ function getHeaderFromRequest(req, name) {
   if (
     typeof (/** @type {Request & ExpectedRequest} */ (req).get) === "function"
   ) {
-    return /** @type {Request & ExpectedRequest} */ (req).get("range");
+    return /** @type {Request & ExpectedRequest} */ (req).get(name);
   }
 
   // Node.js API


### PR DESCRIPTION


This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **documentation update**
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Fix the intention of the code 

### Breaking Changes

None

### Additional Info
