### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/src/utils/getFilenameFromUrl.js
+++ b/src/utils/getFilenameFromUrl.js
@@ -86,7 +86,7 @@ function getFilenameFromUrl(context, url) {
 
       // Strip the `pathname` property from the `publicPath` option from the start of requested url
       // `/complex/foo.js` => `foo.js`
-      const pathname = urlObject.pathname.substr(
+      const pathname = urlObject.pathname.slice(
         publicPathObject.pathname.length
       );
 

--- a/src/utils/setupWriteToDisk.js
+++ b/src/utils/setupWriteToDisk.js
@@ -53,7 +53,7 @@ function setupWriteToDisk(context) {
               const queryStringIdx = targetFile.indexOf("?");
 
               if (queryStringIdx >= 0) {
-                targetFile = targetFile.substr(0, queryStringIdx);
+                targetFile = targetFile.slice(0, queryStringIdx);
               }
 
               let { outputPath } = compiler;

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -281,7 +281,7 @@ describe.each([
           expect(response.headers["content-type"]).toEqual(
             "application/javascript; charset=utf-8"
           );
-          expect(response.text).toBe(codeContent.substr(3000, 501));
+          expect(response.text).toBe(codeContent.slice(3000, 3501));
           expect(response.text.length).toBe(501);
         });
 
@@ -314,7 +314,7 @@ describe.each([
           expect(response.headers["content-type"]).toEqual(
             "application/javascript; charset=utf-8"
           );
-          expect(response.text).toBe(codeContent.substr(3000, 501));
+          expect(response.text).toBe(codeContent.slice(3000, 3501));
           expect(response.text.length).toBe(501);
         });
 
@@ -331,7 +331,7 @@ describe.each([
           expect(response.headers["content-type"]).toEqual(
             "application/javascript; charset=utf-8"
           );
-          expect(response.text).toBe(codeContent.substr(3000, 501));
+          expect(response.text).toBe(codeContent.slice(3000, 3501));
           expect(response.text.length).toBe(501);
         });
 
@@ -348,7 +348,7 @@ describe.each([
           expect(response.headers["content-type"]).toEqual(
             "application/javascript; charset=utf-8"
           );
-          expect(response.text).toBe(codeContent.substr(0, 3501));
+          expect(response.text).toBe(codeContent.slice(0, 3501));
           expect(response.text.length).toBe(3501);
         });
 
@@ -365,7 +365,7 @@ describe.each([
           expect(response.headers["content-type"]).toEqual(
             "application/javascript; charset=utf-8"
           );
-          expect(response.text).toBe(codeContent.substr(0, 801));
+          expect(response.text).toBe(codeContent.slice(0, 801));
           expect(response.text.length).toBe(801);
         });
 


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Breaking Changes

None

### Additional Info
