### PR TITLE
fix: add writeToDisk support for clean: true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -183,11 +183,11 @@ function wdm(compiler, options = {}) {
 
   setupHooks(context);
 
+  setupOutputFileSystem(context);
+
   if (options.writeToDisk) {
     setupWriteToDisk(context);
   }
-
-  setupOutputFileSystem(context);
 
   // Start watching
   if (/** @type {Compiler} */ (context.compiler).watching) {

--- a/src/utils/setupWriteToDisk.js
+++ b/src/utils/setupWriteToDisk.js
@@ -21,6 +21,20 @@ function setupWriteToDisk(context) {
     (context.compiler).compilers || [context.compiler];
 
   for (const compiler of compilers) {
+    if (compiler.outputFileSystem && compiler.options.output.clean) {
+      /** @type {Compiler["outputFileSystem"]} */
+      const { unlink: originalUnlink } = compiler.outputFileSystem;
+      if (originalUnlink) {
+        compiler.outputFileSystem.unlink = (
+          /** @type {String} */ originalPath,
+          /** @type {(arg0?: null | NodeJS.ErrnoException) => void} */ originalCallback
+        ) => {
+          fs.unlink(originalPath, () => {});
+          originalUnlink(originalPath, originalCallback);
+        };
+      }
+    }
+
     compiler.hooks.emit.tap(
       "DevMiddleware",
       /**


### PR DESCRIPTION
This PR contains a:

- [x ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **documentation update**
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

I'm the author of [Nullstack](https://nullstack.app/), one of its build modes targets chrome extensions. 
I use the writeToDisk option in development mode to preview the extensions with HMR, but the middleware was never cleaning up the real FS when MemFS unlinked files, causing the output folder to become bloated over time.

### Breaking Changes

There are no breaking changes.

### Additional Info

The solution I added might be a bit hacky, but it does solve this issue that has been open for a minute: https://github.com/webpack/webpack-dev-middleware/issues/861

I have temporarily moved the unstable branch of Nullstack to use [my fork](https://github.com/nullstack/nullstack/commit/2b755b662206053a8aa80f3495e61ac8587d97bb),  but would love to have this fix merged so i can rollback to the official package 💜