### PR TITLE
docs(readme): correct dev middleware context usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,8 +398,8 @@ In order to develop an app using server-side rendering, we need access to the
 [`stats`](https://github.com/webpack/docs/wiki/node.js-api#stats), which is
 generated with each build.
 
-With server-side rendering enabled, `webpack-dev-middleware` sets the `stats` to `res.locals.webpack.devMiddleware.context.stats`
-and the filesystem to `res.locals.webpack.devMiddleware.context.outputFileSystem` before invoking the next middleware,
+With server-side rendering enabled, `webpack-dev-middleware` sets the `stats` to `res.locals.webpack.devMiddleware.stats`
+and the filesystem to `res.locals.webpack.devMiddleware.outputFileSystem` before invoking the next middleware,
 allowing a developer to render the page body and manage the response to clients.
 
 _Note: Requests for bundle files will still be handled by
@@ -433,8 +433,8 @@ app.use(middleware(compiler, { serverSideRender: true }));
 // The following middleware would not be invoked until the latest build is finished.
 app.use((req, res) => {
   const { devMiddleware } = res.locals.webpack;
-  const outputFileSystem = devMiddleware.context.outputFileSystem;
-  const jsonWebpackStats = devMiddleware.context.stats.toJson();
+  const outputFileSystem = devMiddleware.outputFileSystem;
+  const jsonWebpackStats = devMiddleware.stats.toJson();
   const { assetsByChunkName, outputPath } = jsonWebpackStats;
 
   // Then use `assetsByChunkName` for server-side rendering


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **documentation update**
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

The usage of dev middleware context is mentioned incorrectly in documentation, currently its usage is defined as `devMiddleware.context.stats ` whereas it should be `devMiddleware.stats `.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

No breaking changes.

### Additional Info


Fixes https://github.com/webpack/webpack-dev-middleware/issues/1383