### PR TITLE
Removed cache key logging (closes #1804)

### DIFF
--- a/src/utils/memorize.js
+++ b/src/utils/memorize.js
@@ -14,7 +14,6 @@ function memorize(fn, { cache = new Map() } = {}, callback) {
    */
   const memoized = (...arguments_) => {
     const [key] = arguments_;
-    console.log("CACHE", key);
     const cacheItem = cache.get(key);
 
     if (cacheItem) {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **documentation update**
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

In 7.2.0 console.log was left unintentionally, I assume. Here is a one-liner with the fix.