### PR TITLE
Fix support dev server false

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -519,9 +519,9 @@ function wrapper(context) {
           headers = allHeaders;
         }
 
-        headers.forEach((header) => {
-          setResponseHeader(res, header.key, header.value);
-        });
+        for (const { key, value } of headers) {
+          setResponseHeader(res, key, value);
+        }
       }
 
       if (

--- a/src/utils/getPaths.js
+++ b/src/utils/getPaths.js
@@ -20,7 +20,7 @@ function getPaths(context) {
   const publicPaths = [];
 
   for (const { compilation } of childStats) {
-    if (!compilation.options.devServer) {
+    if (compilation.options.devServer === false) {
       // eslint-disable-next-line no-continue
       continue;
     }

--- a/src/utils/getPaths.js
+++ b/src/utils/getPaths.js
@@ -20,6 +20,11 @@ function getPaths(context) {
   const publicPaths = [];
 
   for (const { compilation } of childStats) {
+    if (!compilation.options.devServer) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
     // The `output.path` is always present and always absolute
     const outputPath = compilation.getPath(
       compilation.outputOptions.path || "",

--- a/src/utils/ready.js
+++ b/src/utils/ready.js
@@ -19,7 +19,6 @@ function ready(context, callback, req) {
   const name = (req && req.url) || callback.name;
 
   context.logger.info(`wait until bundle finished${name ? `: ${name}` : ""}`);
-
   context.callbacks.push(callback);
 }
 

--- a/src/utils/setupHooks.js
+++ b/src/utils/setupHooks.js
@@ -144,14 +144,9 @@ function setupHooks(context) {
       context.callbacks = [];
 
       // Execute callback that are delayed
-      callbacks.forEach(
-        /**
-         * @param {(...args: any[]) => Stats | MultiStats} callback
-         */
-        (callback) => {
-          callback(stats);
-        },
-      );
+      for (const callback of callbacks) {
+        callback(stats);
+      }
     });
   }
 

--- a/src/utils/setupOutputFileSystem.js
+++ b/src/utils/setupOutputFileSystem.js
@@ -30,8 +30,10 @@ function setupOutputFileSystem(context) {
       // TODO we need to support webpack-dev-server as a plugin or revisit it
       const compiler =
         /** @type {MultiCompiler} */
-        (context.compiler).compilers.filter((item) =>
-          Object.prototype.hasOwnProperty.call(item.options, "devServer"),
+        (context.compiler).compilers.filter(
+          (item) =>
+            Object.prototype.hasOwnProperty.call(item.options, "devServer") &&
+            item.options.devServer,
         );
 
       ({ outputFileSystem } =
@@ -48,6 +50,11 @@ function setupOutputFileSystem(context) {
     (context.compiler).compilers || [context.compiler];
 
   for (const compiler of compilers) {
+    if (!compiler.options.devServer) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
     // @ts-ignore
     compiler.outputFileSystem = outputFileSystem;
   }

--- a/src/utils/setupOutputFileSystem.js
+++ b/src/utils/setupOutputFileSystem.js
@@ -33,7 +33,7 @@ function setupOutputFileSystem(context) {
         (context.compiler).compilers.filter(
           (item) =>
             Object.prototype.hasOwnProperty.call(item.options, "devServer") &&
-            item.options.devServer,
+            item.options.devServer !== false,
         );
 
       ({ outputFileSystem } =
@@ -50,7 +50,7 @@ function setupOutputFileSystem(context) {
     (context.compiler).compilers || [context.compiler];
 
   for (const compiler of compilers) {
-    if (!compiler.options.devServer) {
+    if (compiler.options.devServer === false) {
       // eslint-disable-next-line no-continue
       continue;
     }

--- a/src/utils/setupWriteToDisk.js
+++ b/src/utils/setupWriteToDisk.js
@@ -21,6 +21,11 @@ function setupWriteToDisk(context) {
     (context.compiler).compilers || [context.compiler];
 
   for (const compiler of compilers) {
+    if (!compiler.options.devServer) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
     compiler.hooks.emit.tap("DevMiddleware", () => {
       // @ts-ignore
       if (compiler.hasWebpackDevMiddlewareAssetEmittedCallback) {

--- a/src/utils/setupWriteToDisk.js
+++ b/src/utils/setupWriteToDisk.js
@@ -21,7 +21,7 @@ function setupWriteToDisk(context) {
     (context.compiler).compilers || [context.compiler];
 
   for (const compiler of compilers) {
-    if (!compiler.options.devServer) {
+    if (compiler.options.devServer === false) {
       // eslint-disable-next-line no-continue
       continue;
     }

--- a/test/__snapshots__/logging.test.js.snap.webpack5
+++ b/test/__snapshots__/logging.test.js.snap.webpack5
@@ -47,10 +47,8 @@ success (webpack x.x.x) compiled successfully in x ms"
 
 exports[`logging should logging in multi-compiler and respect the "stats" option from configuration #3: stderr 1`] = `""`;
 
-exports[`logging should logging in multi-compiler and respect the "stats" option from configuration #3: stderr 2`] = `""`;
-
 exports[`logging should logging in multi-compiler and respect the "stats" option from configuration #3: stdout 1`] = `
-"asset bundle.js x KiB [emitted] (name: main)
+"asset bundle.js x KiB [compared for emit] (name: main)
 ./broken.js x bytes [built] [code generated] [1 error]
 
 ERROR in ./broken.js 1:3
@@ -61,12 +59,56 @@ You may need an appropriate loader to handle this file type, currently no loader
 
 webpack x.x.x compiled with 1 error in x ms
 
-asset bundle.js x KiB [emitted] (name: main)
+asset bundle.js x KiB [compared for emit] (name: main)
 ./warning.js x bytes [built] [code generated]
 
 WARNING in Warning
 
 webpack x.x.x compiled with 1 warning in x ms
+
+asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
+runtime modules x bytes x modules
+cacheable modules x bytes
+./foo.js x bytes [built] [code generated]
+./svg.svg x bytes [built] [code generated]
+./index.html x bytes [built] [code generated]
+webpack x.x.x compiled successfully in x ms"
+`;
+
+exports[`logging should logging in multi-compiler and respect the "stats" option from configuration #4: stderr 1`] = `""`;
+
+exports[`logging should logging in multi-compiler and respect the "stats" option from configuration #4: stdout 1`] = `
+"asset bundle.js x KiB [compared for emit] (name: main)
+./broken.js x bytes [built] [code generated] [1 error]
+
+ERROR in ./broken.js 1:3
+Module parse failed: Unexpected token (1:3)
+You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
+> 1()2()3()
+|
+
+webpack x.x.x compiled with 1 error in x ms
+
+asset bundle.js x KiB [compared for emit] (name: main)
+./warning.js x bytes [built] [code generated]
+
+WARNING in Warning
+
+webpack x.x.x compiled with 1 warning in x ms
+
+asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)"
+`;
+
+exports[`logging should logging in multi-compiler and respect the "stats" option from configuration #5: stderr 1`] = `""`;
+
+exports[`logging should logging in multi-compiler and respect the "stats" option from configuration #5: stdout 1`] = `
+"asset bundle.js x KiB [emitted] (name: main)
+./bar.js x bytes [built] [code generated]
+webpack x.x.x compiled successfully in x ms
 
 asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
@@ -77,30 +119,6 @@ cacheable modules x bytes
 ./svg.svg x bytes [built] [code generated]
 ./index.html x bytes [built] [code generated]
 webpack x.x.x compiled successfully in x ms"
-`;
-
-exports[`logging should logging in multi-compiler and respect the "stats" option from configuration #3: stdout 2`] = `
-"asset bundle.js x KiB [emitted] (name: main)
-./broken.js x bytes [built] [code generated] [1 error]
-
-ERROR in ./broken.js 1:3
-Module parse failed: Unexpected token (1:3)
-You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-> 1()2()3()
-|
-
-webpack x.x.x compiled with 1 error in x ms
-
-asset bundle.js x KiB [emitted] (name: main)
-./warning.js x bytes [built] [code generated]
-
-WARNING in Warning
-
-webpack x.x.x compiled with 1 warning in x ms
-
-asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)"
 `;
 
 exports[`logging should logging in multi-compiler and respect the "stats" option from configuration: stderr 1`] = `""`;
@@ -124,9 +142,9 @@ WARNING in Warning
 
 webpack x.x.x compiled with 1 warning in x ms
 
-asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
+asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
 runtime modules x bytes x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -138,9 +156,9 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully build and respect colors #2: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build and respect colors #2: stdout 1`] = `
-"asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
 runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -152,9 +170,9 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully build and respect colors: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build and respect colors: stdout 1`] = `
-"asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
 runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -166,9 +184,9 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully build and respect the "NO_COLOR" env: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build and respect the "NO_COLOR" env: stdout 1`] = `
-"asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
 runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -180,9 +198,9 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully build and respect the "stats" option from configuration with custom object value: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build and respect the "stats" option from configuration with custom object value: stdout 1`] = `
-"asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)"
+"asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)"
 `;
 
 exports[`logging should logging on successfully build and respect the "stats" option from configuration with the "false" value: stderr 1`] = `""`;
@@ -204,9 +222,9 @@ exports[`logging should logging on successfully build and respect the "stats" op
 exports[`logging should logging on successfully build and respect the "stats" option from configuration with the "true" value: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build and respect the "stats" option from configuration with the "true" value: stdout 1`] = `
-"asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
 runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -219,9 +237,9 @@ exports[`logging should logging on successfully build and respect the "stats" op
 
 exports[`logging should logging on successfully build and respect the "stats" option from configuration with the "verbose" value: stdout 1`] = `
 "PublicPath: auto
-asset bundle.js x KiB {main} [emitted] (name: main)
-asset svg.svg x KiB ({main}) [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes ({main}) [emitted] [from: index.html] (auxiliary name: main)
+asset bundle.js x KiB {main} [compared for emit] (name: main)
+asset svg.svg x KiB ({main}) [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes ({main}) [compared for emit] [from: index.html] (auxiliary name: main)
 Entrypoint main x KiB (x KiB) = bundle.js 2 auxiliary assets
 chunk {main} (runtime: main) bundle.js (xxxx) x bytes (xxxx) x KiB (xxxx) [entry] [rendered]
 > ./foo.js main
@@ -279,17 +297,17 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully build using the "stats" option for middleware with object value and no colors: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build using the "stats" option for middleware with object value and no colors: stdout 1`] = `
-"asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)"
+"asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)"
 `;
 
 exports[`logging should logging on successfully build using the "stats" option for middleware with object value: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build using the "stats" option for middleware with object value: stdout 1`] = `
-"asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)"
+"asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)"
 `;
 
 exports[`logging should logging on successfully build using the "stats" option for middleware with the "false" value: stderr 1`] = `""`;
@@ -303,9 +321,9 @@ exports[`logging should logging on successfully build using the "stats" option f
 exports[`logging should logging on successfully build using the "stats" option for middleware with the "normal" value: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build using the "stats" option for middleware with the "normal" value: stdout 1`] = `
-"asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
 runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -317,9 +335,9 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully build using the "stats" option for middleware with the "true" value: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build using the "stats" option for middleware with the "true" value: stdout 1`] = `
-"asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
 runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -332,9 +350,9 @@ exports[`logging should logging on successfully build using the "stats" option f
 
 exports[`logging should logging on successfully build using the "stats" option for middleware with the "verbose" value: stdout 1`] = `
 "PublicPath: auto
-asset bundle.js x KiB {main} [emitted] (name: main)
-asset svg.svg x KiB ({main}) [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes ({main}) [emitted] [from: index.html] (auxiliary name: main)
+asset bundle.js x KiB {main} [compared for emit] (name: main)
+asset svg.svg x KiB ({main}) [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes ({main}) [compared for emit] [from: index.html] (auxiliary name: main)
 Entrypoint main x KiB (x KiB) = bundle.js 2 auxiliary assets
 chunk {main} (runtime: main) bundle.js (xxxx) x bytes (xxxx) x KiB (xxxx) [entry] [rendered]
 > ./foo.js main
@@ -374,17 +392,17 @@ LOG from xxx"
 exports[`logging should logging on successfully build using the "stats" option for middleware with the object value and colors: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build using the "stats" option for middleware with the object value and colors: stdout 1`] = `
-"asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)"
+"asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)"
 `;
 
 exports[`logging should logging on successfully build when the 'stats' doesn't exist: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build when the 'stats' doesn't exist: stdout 1`] = `
-"asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
 runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -410,21 +428,21 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with object value and colors: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with object value and colors: stdout 1`] = `
-"asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
 
-asset bundle.js x KiB [emitted] (name: main)"
+asset bundle.js x KiB [compared for emit] (name: main)"
 `;
 
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with object value and no colors: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with object value and no colors: stdout 1`] = `
-"asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
 
-asset bundle.js x KiB [emitted] (name: main)"
+asset bundle.js x KiB [compared for emit] (name: main)"
 `;
 
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with the "false" value: stderr 1`] = `""`;
@@ -434,9 +452,9 @@ exports[`logging should logging on successfully multi-compiler build using the "
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with the "normal" value: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with the "normal" value: stdout 1`] = `
-"asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
 runtime modules x bytes x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -444,7 +462,7 @@ cacheable modules x bytes
 ./index.html x bytes [built] [code generated]
 webpack x.x.x compiled successfully in x ms
 
-asset bundle.js x KiB [emitted] (name: main)
+asset bundle.js x KiB [compared for emit] (name: main)
 ./bar.js x bytes [built] [code generated]
 webpack x.x.x compiled successfully in x ms"
 `;
@@ -452,9 +470,9 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with the "true" value: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with the "true" value: stdout 1`] = `
-"asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
 runtime modules x bytes x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -462,7 +480,7 @@ cacheable modules x bytes
 ./index.html x bytes [built] [code generated]
 webpack x.x.x compiled successfully in x ms
 
-asset bundle.js x KiB [emitted] (name: main)
+asset bundle.js x KiB [compared for emit] (name: main)
 ./bar.js x bytes [built] [code generated]
 webpack x.x.x compiled successfully in x ms"
 `;
@@ -470,11 +488,11 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with the object value: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with the object value: stdout 1`] = `
-"asset bundle.js x KiB [emitted] (name: main)
-asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [compared for emit] (name: main)
+asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
 
-asset bundle.js x KiB [emitted] (name: main)"
+asset bundle.js x KiB [compared for emit] (name: main)"
 `;
 
 exports[`logging should logging on unsuccessful build in multi-compiler: stderr 1`] = `""`;

--- a/test/__snapshots__/logging.test.js.snap.webpack5
+++ b/test/__snapshots__/logging.test.js.snap.webpack5
@@ -48,7 +48,7 @@ success (webpack x.x.x) compiled successfully in x ms"
 exports[`logging should logging in multi-compiler and respect the "stats" option from configuration #3: stderr 1`] = `""`;
 
 exports[`logging should logging in multi-compiler and respect the "stats" option from configuration #3: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
+"asset bundle.js x KiB [emitted] (name: main)
 ./broken.js x bytes [built] [code generated] [1 error]
 
 ERROR in ./broken.js 1:3
@@ -59,16 +59,16 @@ You may need an appropriate loader to handle this file type, currently no loader
 
 webpack x.x.x compiled with 1 error in x ms
 
-asset bundle.js x KiB [compared for emit] (name: main)
+asset bundle.js x KiB [emitted] (name: main)
 ./warning.js x bytes [built] [code generated]
 
 WARNING in Warning
 
 webpack x.x.x compiled with 1 warning in x ms
 
-asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
+asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
 runtime modules x bytes x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -80,7 +80,7 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging in multi-compiler and respect the "stats" option from configuration #4: stderr 1`] = `""`;
 
 exports[`logging should logging in multi-compiler and respect the "stats" option from configuration #4: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
+"asset bundle.js x KiB [emitted] (name: main)
 ./broken.js x bytes [built] [code generated] [1 error]
 
 ERROR in ./broken.js 1:3
@@ -91,16 +91,16 @@ You may need an appropriate loader to handle this file type, currently no loader
 
 webpack x.x.x compiled with 1 error in x ms
 
-asset bundle.js x KiB [compared for emit] (name: main)
+asset bundle.js x KiB [emitted] (name: main)
 ./warning.js x bytes [built] [code generated]
 
 WARNING in Warning
 
 webpack x.x.x compiled with 1 warning in x ms
 
-asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)"
+asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)"
 `;
 
 exports[`logging should logging in multi-compiler and respect the "stats" option from configuration #5: stderr 1`] = `""`;
@@ -142,9 +142,9 @@ WARNING in Warning
 
 webpack x.x.x compiled with 1 warning in x ms
 
-asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
+asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
 runtime modules x bytes x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -156,9 +156,9 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully build and respect colors #2: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build and respect colors #2: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
 runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -170,9 +170,9 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully build and respect colors: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build and respect colors: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
 runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -184,9 +184,9 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully build and respect the "NO_COLOR" env: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build and respect the "NO_COLOR" env: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
 runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -198,9 +198,9 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully build and respect the "stats" option from configuration with custom object value: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build and respect the "stats" option from configuration with custom object value: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)"
+"asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)"
 `;
 
 exports[`logging should logging on successfully build and respect the "stats" option from configuration with the "false" value: stderr 1`] = `""`;
@@ -222,9 +222,9 @@ exports[`logging should logging on successfully build and respect the "stats" op
 exports[`logging should logging on successfully build and respect the "stats" option from configuration with the "true" value: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build and respect the "stats" option from configuration with the "true" value: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
 runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -237,9 +237,9 @@ exports[`logging should logging on successfully build and respect the "stats" op
 
 exports[`logging should logging on successfully build and respect the "stats" option from configuration with the "verbose" value: stdout 1`] = `
 "PublicPath: auto
-asset bundle.js x KiB {main} [compared for emit] (name: main)
-asset svg.svg x KiB ({main}) [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes ({main}) [compared for emit] [from: index.html] (auxiliary name: main)
+asset bundle.js x KiB {main} [emitted] (name: main)
+asset svg.svg x KiB ({main}) [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes ({main}) [emitted] [from: index.html] (auxiliary name: main)
 Entrypoint main x KiB (x KiB) = bundle.js 2 auxiliary assets
 chunk {main} (runtime: main) bundle.js (xxxx) x bytes (xxxx) x KiB (xxxx) [entry] [rendered]
 > ./foo.js main
@@ -297,17 +297,17 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully build using the "stats" option for middleware with object value and no colors: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build using the "stats" option for middleware with object value and no colors: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)"
+"asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)"
 `;
 
 exports[`logging should logging on successfully build using the "stats" option for middleware with object value: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build using the "stats" option for middleware with object value: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)"
+"asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)"
 `;
 
 exports[`logging should logging on successfully build using the "stats" option for middleware with the "false" value: stderr 1`] = `""`;
@@ -321,9 +321,9 @@ exports[`logging should logging on successfully build using the "stats" option f
 exports[`logging should logging on successfully build using the "stats" option for middleware with the "normal" value: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build using the "stats" option for middleware with the "normal" value: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
 runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -335,9 +335,9 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully build using the "stats" option for middleware with the "true" value: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build using the "stats" option for middleware with the "true" value: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
 runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -350,9 +350,9 @@ exports[`logging should logging on successfully build using the "stats" option f
 
 exports[`logging should logging on successfully build using the "stats" option for middleware with the "verbose" value: stdout 1`] = `
 "PublicPath: auto
-asset bundle.js x KiB {main} [compared for emit] (name: main)
-asset svg.svg x KiB ({main}) [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes ({main}) [compared for emit] [from: index.html] (auxiliary name: main)
+asset bundle.js x KiB {main} [emitted] (name: main)
+asset svg.svg x KiB ({main}) [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes ({main}) [emitted] [from: index.html] (auxiliary name: main)
 Entrypoint main x KiB (x KiB) = bundle.js 2 auxiliary assets
 chunk {main} (runtime: main) bundle.js (xxxx) x bytes (xxxx) x KiB (xxxx) [entry] [rendered]
 > ./foo.js main
@@ -392,17 +392,17 @@ LOG from xxx"
 exports[`logging should logging on successfully build using the "stats" option for middleware with the object value and colors: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build using the "stats" option for middleware with the object value and colors: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)"
+"asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)"
 `;
 
 exports[`logging should logging on successfully build when the 'stats' doesn't exist: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully build when the 'stats' doesn't exist: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
 runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -428,21 +428,21 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with object value and colors: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with object value and colors: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
 
-asset bundle.js x KiB [compared for emit] (name: main)"
+asset bundle.js x KiB [emitted] (name: main)"
 `;
 
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with object value and no colors: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with object value and no colors: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
 
-asset bundle.js x KiB [compared for emit] (name: main)"
+asset bundle.js x KiB [emitted] (name: main)"
 `;
 
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with the "false" value: stderr 1`] = `""`;
@@ -452,9 +452,9 @@ exports[`logging should logging on successfully multi-compiler build using the "
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with the "normal" value: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with the "normal" value: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
 runtime modules x bytes x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -462,7 +462,7 @@ cacheable modules x bytes
 ./index.html x bytes [built] [code generated]
 webpack x.x.x compiled successfully in x ms
 
-asset bundle.js x KiB [compared for emit] (name: main)
+asset bundle.js x KiB [emitted] (name: main)
 ./bar.js x bytes [built] [code generated]
 webpack x.x.x compiled successfully in x ms"
 `;
@@ -470,9 +470,9 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with the "true" value: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with the "true" value: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
 runtime modules x bytes x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
@@ -480,7 +480,7 @@ cacheable modules x bytes
 ./index.html x bytes [built] [code generated]
 webpack x.x.x compiled successfully in x ms
 
-asset bundle.js x KiB [compared for emit] (name: main)
+asset bundle.js x KiB [emitted] (name: main)
 ./bar.js x bytes [built] [code generated]
 webpack x.x.x compiled successfully in x ms"
 `;
@@ -488,11 +488,11 @@ webpack x.x.x compiled successfully in x ms"
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with the object value: stderr 1`] = `""`;
 
 exports[`logging should logging on successfully multi-compiler build using the "stats" option for middleware with the object value: stdout 1`] = `
-"asset bundle.js x KiB [compared for emit] (name: main)
-asset svg.svg x KiB [compared for emit] [from: svg.svg] (auxiliary name: main)
-asset index.html x bytes [compared for emit] [from: index.html] (auxiliary name: main)
+"asset bundle.js x KiB [emitted] (name: main)
+asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
+asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
 
-asset bundle.js x KiB [compared for emit] (name: main)"
+asset bundle.js x KiB [emitted] (name: main)"
 `;
 
 exports[`logging should logging on unsuccessful build in multi-compiler: stderr 1`] = `""`;

--- a/test/fixtures/webpack.array.dev-server-false.js
+++ b/test/fixtures/webpack.array.dev-server-false.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const path = require('path');
+
+module.exports = [
+  {
+    mode: 'development',
+    context: path.resolve(__dirname),
+    entry: './bar.js',
+    output: {
+      filename: 'bundle.js',
+      path: path.resolve(__dirname, '../outputs/array/js3'),
+      publicPath: '/static-two/',
+    },
+    infrastructureLogging: {
+      level: 'none'
+    },
+    stats: 'normal',
+    devServer: false,
+  },
+  {
+    mode: 'development',
+    context: path.resolve(__dirname),
+    entry: './foo.js',
+    output: {
+      filename: 'bundle.js',
+      path: path.resolve(__dirname, '../outputs/array/js4'),
+      publicPath: '/static-one/',
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(svg|html)$/,
+          loader: 'file-loader',
+          options: { name: '[name].[ext]' },
+        },
+      ],
+    },
+    infrastructureLogging: {
+      level: 'none'
+    },
+    stats: 'normal'
+  }
+];

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -854,7 +854,7 @@ describe("logging", () => {
     });
   });
 
-  it('should logging in multi-compiler and respect the "stats" option from configuration #3', (done) => {
+  it('should logging in multi-compiler and respect the "stats" option from configuration #4', (done) => {
     let proc;
 
     try {
@@ -862,6 +862,50 @@ describe("logging", () => {
         stdio: "pipe",
         env: {
           WEBPACK_CONFIG: "webpack.array.one-error-one-warning-one-object",
+          FORCE_COLOR: true,
+        },
+      });
+    } catch (error) {
+      throw error;
+    }
+
+    let stdout = "";
+    let stderr = "";
+
+    proc.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+
+      if (/compiled-for-tests/gi.test(stdout)) {
+        proc.stdin.write("|exit|");
+      }
+    });
+
+    proc.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+      proc.stdin.write("|exit|");
+    });
+
+    proc.on("error", (error) => {
+      done(error);
+    });
+
+    proc.on("exit", () => {
+      expect(stdout).toContain("\u001b[1m");
+      expect(stdoutToSnapshot(stdout)).toMatchSnapshot("stdout");
+      expect(stderrToSnapshot(stderr)).toMatchSnapshot("stderr");
+
+      done();
+    });
+  });
+
+  it('should logging in multi-compiler and respect the "stats" option from configuration #5', (done) => {
+    let proc;
+
+    try {
+      proc = execa(runner, [], {
+        stdio: "pipe",
+        env: {
+          WEBPACK_CONFIG: "webpack.array.dev-server-false",
           FORCE_COLOR: true,
         },
       });

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -65,6 +65,13 @@ function stderrToSnapshot(stderr) {
 const runner = path.resolve(__dirname, "./helpers/runner.js");
 
 describe("logging", () => {
+  beforeEach(async () => {
+    await fs.promises.rm(path.resolve(__dirname, "./outputs/"), {
+      recursive: true,
+      force: true,
+    });
+  });
+
   it("should logging on successfully build", (done) => {
     let proc;
 

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -841,6 +841,11 @@ describe.each([
         const outputPath = path.resolve(__dirname, "./outputs/basic-test");
 
         beforeAll(async () => {
+          await fs.promises.rm(path.resolve(__dirname, "./outputs/"), {
+            recursive: true,
+            force: true,
+          });
+
           compiler = getCompiler({
             ...webpackConfig,
             output: {
@@ -1419,6 +1424,11 @@ describe.each([
 
       describe("should work in multi-compiler mode with `devServer` false", () => {
         beforeAll(async () => {
+          await fs.promises.rm(path.resolve(__dirname, "./outputs/"), {
+            recursive: true,
+            force: true,
+          });
+
           const compiler = getCompiler(webpackMultiDevServerFalseConfig);
 
           [server, req, instance] = await frameworkFactory(
@@ -3605,6 +3615,11 @@ describe.each([
         let compiler;
 
         beforeAll(async () => {
+          await fs.promises.rm(path.resolve(__dirname, "./outputs/"), {
+            recursive: true,
+            force: true,
+          });
+
           compiler = getCompiler({
             ...webpackConfig,
             output: {
@@ -3694,6 +3709,11 @@ describe.each([
         let compiler;
 
         beforeAll(async () => {
+          await fs.promises.rm(outputPath, {
+            recursive: true,
+            force: true,
+          });
+
           compiler = getCompiler({
             ...webpackConfig,
             output: {
@@ -3823,6 +3843,11 @@ describe.each([
         let compiler;
 
         beforeAll(async () => {
+          await fs.promises.rm(path.resolve(__dirname, "./outputs/"), {
+            recursive: true,
+            force: true,
+          });
+
           compiler = getCompiler({
             ...webpackConfig,
             output: {
@@ -3873,6 +3898,11 @@ describe.each([
         let compiler;
 
         beforeAll(async () => {
+          await fs.promises.rm(path.resolve(__dirname, "./outputs/"), {
+            recursive: true,
+            force: true,
+          });
+
           compiler = getCompiler({
             ...webpackConfig,
             output: {
@@ -3923,6 +3953,11 @@ describe.each([
         let compiler;
 
         beforeAll(async () => {
+          await fs.promises.rm(path.resolve(__dirname, "./outputs/"), {
+            recursive: true,
+            force: true,
+          });
+
           compiler = getCompiler({
             ...webpackQueryStringConfig,
             output: {
@@ -3971,6 +4006,11 @@ describe.each([
         let compiler;
 
         beforeAll(async () => {
+          await fs.promises.rm(path.resolve(__dirname, "./outputs/"), {
+            recursive: true,
+            force: true,
+          });
+
           compiler = getCompiler([
             {
               ...webpackMultiWatchOptionsConfig[0],
@@ -4044,6 +4084,11 @@ describe.each([
         let hash;
 
         beforeAll(async () => {
+          await fs.promises.rm(path.resolve(__dirname, "./outputs/"), {
+            recursive: true,
+            force: true,
+          });
+
           compiler = getCompiler({
             ...webpackConfig,
             ...{

--- a/test/utils/setupOutputFileSystem.test.js
+++ b/test/utils/setupOutputFileSystem.test.js
@@ -17,7 +17,7 @@ describe("setupOutputFileSystem", () => {
 
   it("should create default fs if not provided", () => {
     const context = {
-      compiler: {},
+      compiler: { options: {} },
       options: {},
     };
 
@@ -32,7 +32,7 @@ describe("setupOutputFileSystem", () => {
   it("should set fs for multi compiler", () => {
     const context = {
       compiler: {
-        compilers: [{}, {}],
+        compilers: [{ options: {} }, { options: {} }],
       },
       options: {},
     };
@@ -46,7 +46,7 @@ describe("setupOutputFileSystem", () => {
 
   it("should use provided fs with correct methods", () => {
     const context = {
-      compiler: {},
+      compiler: { options: {} },
       options: {
         outputFileSystem: {
           join: () => {},


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **documentation update**
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

ref https://github.com/webpack/webpack-cli/pull/4045/

### Breaking Changes

No

### Additional Info

When you have `devServer: false` in your multi comiler mode we will just watch and do not server, so you can use something like:
```js
const path = require("path");

module.exports = [
  {
    target: "webworker",
    mode: "development",
    entry: "./workers/worker.js",
    output: {
      path: path.resolve(__dirname, `public`),
    },
    devServer: false,
  },
  {
    devtool: false,
    mode: "development",
    entry: "./entries/entry1.js",
    output: {
      path: path.resolve(__dirname, `static`),
      publicPath: "/static/"
    },
    devServer: {
      host: "localhost",
    },
  },
];
```

Useful when you have something what should just bundle and handle like static content - https://expressjs.com/en/starter/static-files.html