### PR TITLE
fix: do not call the next middleware for 304 response

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -606,6 +606,8 @@ function honoWrapper(compiler, options) {
             body = data;
           };
 
+          let isFinished = false;
+
           /**
            * @param {(string | Buffer)=} data data
            */
@@ -618,6 +620,9 @@ function honoWrapper(compiler, options) {
             }
 
             body = isDataExist ? data : null;
+            isFinished = true;
+
+            resolve();
           };
 
           devMiddleware(req, res, (err) => {
@@ -626,7 +631,9 @@ function honoWrapper(compiler, options) {
               return;
             }
 
-            resolve();
+            if (!isFinished) {
+              resolve();
+            }
           });
         },
       );

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -719,7 +719,6 @@ function wrapper(context) {
           removeResponseHeader(res, "Content-Type");
 
           finish(res);
-          await goNext();
           return;
         }
       }


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **documentation update**
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes - https://github.com/webpack/webpack-dev-server/issues/5519

### Breaking Changes

Mostly no, potentially some application allow to change status code and remove headers, but webpack-dev-middleware should be the last point in middlewares, so this change fixes bugs when other middleware is trying to write headers/body

### Additional Info

Inspired by - https://github.com/pillarjs/send/blob/master/index.js#L273