### PR TITLE
fix: do not call the next middleware when request is finished or errored

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -425,6 +425,7 @@ function koaWrapper(compiler, options) {
     };
 
     let isFinished = false;
+    let needNext = false;
 
     try {
       await new Promise(
@@ -469,6 +470,8 @@ function koaWrapper(compiler, options) {
               return;
             }
 
+            needNext = true;
+
             if (!isFinished) {
               resolve();
             }
@@ -486,7 +489,9 @@ function koaWrapper(compiler, options) {
       };
     }
 
-    await next();
+    if (needNext) {
+      await next();
+    }
   }
 
   webpackDevMiddleware.devMiddleware = devMiddleware;

--- a/src/index.js
+++ b/src/index.js
@@ -424,6 +424,8 @@ function koaWrapper(compiler, options) {
       ctx.status = statusCode;
     };
 
+    let isFinished = false;
+
     try {
       await new Promise(
         /**
@@ -436,12 +438,18 @@ function koaWrapper(compiler, options) {
            */
           res.stream = (stream) => {
             ctx.body = stream;
+
+            isFinished = true;
+            resolve();
           };
           /**
            * @param {string | Buffer} data data
            */
           res.send = (data) => {
             ctx.body = data;
+
+            isFinished = true;
+            resolve();
           };
 
           /**
@@ -450,6 +458,9 @@ function koaWrapper(compiler, options) {
           res.finish = (data) => {
             ctx.status = status;
             res.end(data);
+
+            isFinished = true;
+            resolve();
           };
 
           devMiddleware(req, res, (err) => {
@@ -458,7 +469,9 @@ function koaWrapper(compiler, options) {
               return;
             }
 
-            resolve();
+            if (!isFinished) {
+              resolve();
+            }
           });
         },
       );

--- a/src/index.js
+++ b/src/index.js
@@ -424,8 +424,6 @@ function koaWrapper(compiler, options) {
       ctx.status = statusCode;
     };
 
-    res.getReadyReadableStreamState = () => "open";
-
     try {
       await new Promise(
         /**
@@ -574,8 +572,6 @@ function honoWrapper(compiler, options) {
     res.setState = () => {
       // Do nothing, because we set it before
     };
-
-    res.getReadyReadableStreamState = () => "readable";
 
     res.getHeadersSent = () => context.env.outgoing.headersSent;
 

--- a/src/index.js
+++ b/src/index.js
@@ -576,6 +576,7 @@ function honoWrapper(compiler, options) {
     res.getHeadersSent = () => context.env.outgoing.headersSent;
 
     let body;
+    let isFinished = false;
 
     try {
       await new Promise(
@@ -589,7 +590,9 @@ function honoWrapper(compiler, options) {
            */
           res.stream = (stream) => {
             body = stream;
-            // responseHandler(stream);
+
+            isFinished = true;
+            resolve();
           };
 
           /**
@@ -600,9 +603,10 @@ function honoWrapper(compiler, options) {
             context.res.headers.delete("Content-Length");
 
             body = data;
-          };
 
-          let isFinished = false;
+            isFinished = true;
+            resolve();
+          };
 
           /**
            * @param {(string | Buffer)=} data data
@@ -616,8 +620,8 @@ function honoWrapper(compiler, options) {
             }
 
             body = isDataExist ? data : null;
-            isFinished = true;
 
+            isFinished = true;
             resolve();
           };
 

--- a/src/utils/compatibleAPI.js
+++ b/src/utils/compatibleAPI.js
@@ -24,7 +24,6 @@
  * @property {((data: any) => void)=} stream stream
  * @property {(() => any)=} getOutgoing get outgoing
  * @property {((name: string, value: any) => void)=} setState set state
- * @property {(() => "ready" | "open" | "readable")=} getReadyReadableStreamState get ready readable streamState
  */
 
 /**
@@ -301,26 +300,11 @@ function setState(res, name, value) {
   (res.locals)[name] = value;
 }
 
-/**
- * @template {ServerResponse & ExpectedServerResponse} Response
- * @param {Response} res res
- * @returns {"ready" | "open" | "readable"} state
- */
-function getReadyReadableStreamState(res) {
-  // Pseudo API and Express API and Koa API
-  if (typeof res.getReadyReadableStreamState === "function") {
-    return res.getReadyReadableStreamState();
-  }
-
-  return "ready";
-}
-
 module.exports = {
   createReadStreamOrReadFileSync,
   finish,
   getHeadersSent,
   getOutgoing,
-  getReadyReadableStreamState,
   getRequestHeader,
   getRequestMethod,
   getRequestURL,

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -3325,12 +3325,7 @@ describe.each([
                   });
                   middlewares.push(middleware.koaWrapper(compiler, {}));
                 } else if (name === "hono") {
-                  middlewares.unshift(async (c, next) => {
-                    await next();
-
-                    return new Response("Hello Node.js!");
-                  });
-                  middlewares.push(middleware.honoWrapper(compiler, {}));
+                  // Hono doesn't have this problem due design
                 } else {
                   middlewares.push({
                     route: "/",
@@ -3377,6 +3372,187 @@ describe.each([
             "text/html; charset=utf-8",
           );
           expect(response.text).toBeUndefined();
+        });
+      });
+
+      describe("should work and don't call the next middleware for finished or errored requests by default", () => {
+        let compiler;
+
+        const outputPath = path.resolve(
+          __dirname,
+          "./outputs/basic-test-errors-headers-sent",
+        );
+
+        let nextWasCalled = false;
+
+        beforeAll(async () => {
+          compiler = getCompiler({
+            ...webpackConfig,
+            output: {
+              filename: "bundle.js",
+              path: outputPath,
+            },
+          });
+
+          [server, req, instance] = await frameworkFactory(
+            name,
+            framework,
+            compiler,
+            {
+              etag: "weak",
+            },
+            {
+              setupMiddlewares: (middlewares) => {
+                if (name === "hapi") {
+                  // There's no such thing as "the next route handler" in hapi. One request is matched to one or no route handlers.
+                } else if (name === "koa") {
+                  middlewares.push(middleware.koaWrapper(compiler, {}));
+                  middlewares.push(async () => {
+                    nextWasCalled = true;
+                  });
+                } else if (name === "hono") {
+                  // Hono doesn't have this problem due design
+                } else {
+                  middlewares.push(middleware(compiler, {}));
+                  middlewares.push(() => {
+                    nextWasCalled = true;
+                  });
+                }
+
+                return middlewares;
+              },
+            },
+          );
+
+          instance.context.outputFileSystem.mkdirSync(outputPath, {
+            recursive: true,
+          });
+          instance.context.outputFileSystem.writeFileSync(
+            path.resolve(outputPath, "index.html"),
+            "HTML",
+          );
+          instance.context.outputFileSystem.writeFileSync(
+            path.resolve(outputPath, "image.svg"),
+            "svg image",
+          );
+
+          const originalMethod =
+            instance.context.outputFileSystem.createReadStream;
+
+          instance.context.outputFileSystem.createReadStream =
+            function createReadStream(...args) {
+              if (args[0].endsWith("image.svg")) {
+                const brokenStream = new this.ReadStream(...args);
+
+                brokenStream._read = function _read() {
+                  const error = new Error("test");
+                  error.code = "ENAMETOOLONG";
+                  this.emit("error", error);
+                  this.end();
+                  this.destroy();
+                };
+
+                return brokenStream;
+              }
+
+              return originalMethod(...args);
+            };
+        });
+
+        afterAll(async () => {
+          await close(server, instance);
+        });
+
+        it("should work with piping stream", async () => {
+          const response1 = await req.get("/");
+
+          expect(response1.statusCode).toBe(200);
+          expect(nextWasCalled).toBe(false);
+        });
+
+        it("should not allow to get files above root", async () => {
+          const response = await req.get("/public/..%2f../middleware.test.js");
+
+          expect(response.statusCode).toBe(403);
+          expect(response.headers["content-type"]).toBe(
+            "text/html; charset=utf-8",
+          );
+          expect(response.text).toBe(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Error</title>
+</head>
+<body>
+<pre>Forbidden</pre>
+</body>
+</html>`);
+          expect(nextWasCalled).toBe(false);
+        });
+
+        it('should return the "412" code for the "GET" request to the bundle file with etag and wrong "if-match" header', async () => {
+          const response1 = await req.get("/");
+
+          expect(response1.statusCode).toBe(200);
+          expect(response1.headers.etag).toBeDefined();
+          expect(response1.headers.etag.startsWith("W/")).toBe(true);
+
+          const response2 = await req.get("/").set("if-match", "test");
+
+          expect(response2.statusCode).toBe(412);
+          expect(nextWasCalled).toBe(false);
+        });
+
+        it('should return the "416" code for the "GET" request with the invalid range header', async () => {
+          const response = await req.get("/").set("Range", "bytes=9999999-");
+
+          expect(response.statusCode).toBe(416);
+          expect(response.headers["content-type"]).toBe(
+            "text/html; charset=utf-8",
+          );
+          expect(response.text).toBe(
+            `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Error</title>
+</head>
+<body>
+<pre>Range Not Satisfiable</pre>
+</body>
+</html>`,
+          );
+          expect(nextWasCalled).toBe(false);
+        });
+
+        it('should return the "404" code for the "GET" request to the "image.svg" file when it throws a reading error', async () => {
+          const response = await req.get("/image.svg");
+
+          expect(response.statusCode).toBe(404);
+          expect(response.headers["content-type"]).toBe(
+            "text/html; charset=utf-8",
+          );
+          expect(response.text).toEqual(
+            "<!DOCTYPE html>\n" +
+              '<html lang="en">\n' +
+              "<head>\n" +
+              '<meta charset="utf-8">\n' +
+              "<title>Error</title>\n" +
+              "</head>\n" +
+              "<body>\n" +
+              "<pre>Not Found</pre>\n" +
+              "</body>\n" +
+              "</html>",
+          );
+          expect(nextWasCalled).toBe(false);
+        });
+
+        it.only('should return the "200" code for the "HEAD" request to the bundle file', async () => {
+          const response = await req.head("/");
+
+          expect(response.statusCode).toBe(200);
+          expect(response.text).toBeUndefined();
+          expect(nextWasCalled).toBe(false);
         });
       });
     });

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -3547,7 +3547,7 @@ describe.each([
           expect(nextWasCalled).toBe(false);
         });
 
-        it.only('should return the "200" code for the "HEAD" request to the bundle file', async () => {
+        it('should return the "200" code for the "HEAD" request to the bundle file', async () => {
           const response = await req.head("/");
 
           expect(response.statusCode).toBe(200);

--- a/types/utils/compatibleAPI.d.ts
+++ b/types/utils/compatibleAPI.d.ts
@@ -69,12 +69,6 @@ export type ExpectedServerResponse = {
    * set state
    */
   setState?: ((name: string, value: any) => void) | undefined;
-  /**
-   * get ready readable streamState
-   */
-  getReadyReadableStreamState?:
-    | (() => "ready" | "open" | "readable")
-    | undefined;
 };
 /**
  * @param {string} filename filename
@@ -116,14 +110,6 @@ export function getHeadersSent<
 export function getOutgoing<
   Response extends ServerResponse & ExpectedServerResponse,
 >(res: Response): Response;
-/**
- * @template {ServerResponse & ExpectedServerResponse} Response
- * @param {Response} res res
- * @returns {"ready" | "open" | "readable"} state
- */
-export function getReadyReadableStreamState<
-  Response extends ServerResponse & ExpectedServerResponse,
->(res: Response): "ready" | "open" | "readable";
 /** @typedef {import("../index.js").IncomingMessage} IncomingMessage */
 /** @typedef {import("../index.js").ServerResponse} ServerResponse */
 /** @typedef {import("../index").OutputFileSystem} OutputFileSystem */
@@ -147,7 +133,6 @@ export function getReadyReadableStreamState<
  * @property {((data: any) => void)=} stream stream
  * @property {(() => any)=} getOutgoing get outgoing
  * @property {((name: string, value: any) => void)=} setState set state
- * @property {(() => "ready" | "open" | "readable")=} getReadyReadableStreamState get ready readable streamState
  */
 /**
  * @template {IncomingMessage & ExpectedIncomingMessage} Request


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **documentation update**
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes - https://github.com/webpack/webpack-dev-middleware/issues/2150

### Breaking Changes

Technically yes, but doing something after request was sent or errors is mostly a bug, so this change is a fix

### Additional Info

No
