### PR TITLE
chore: remove colorette dependency and update minimum webpack version to 5.101.0

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -3,7 +3,6 @@
   "language": "en,en-gb",
   "words": [
     "memfs",
-    "colorette",
     "noextension",
     "fullhash",
     "execa",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "7.4.5",
       "license": "MIT",
       "dependencies": {
-        "colorette": "^2.0.10",
         "memfs": "^4.43.1",
         "mime-types": "^3.0.1",
         "on-finished": "^2.4.1",
@@ -75,7 +74,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.0.0"
+        "webpack": "^5.101.0"
       },
       "peerDependenciesMeta": {
         "webpack": {
@@ -7373,6 +7372,7 @@
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "release": "standard-version"
   },
   "dependencies": {
-    "colorette": "^2.0.10",
     "memfs": "^4.43.1",
     "mime-types": "^3.0.1",
     "on-finished": "^2.4.1",
@@ -106,7 +105,7 @@
     "webpack": "^5.101.0"
   },
   "peerDependencies": {
-    "webpack": "^5.0.0"
+    "webpack": "^5.101.0"
   },
   "peerDependenciesMeta": {
     "webpack": {

--- a/src/utils/setupHooks.js
+++ b/src/utils/setupHooks.js
@@ -113,14 +113,8 @@ function setupHooks(context) {
                   /** @type {MultiCompiler} */
                   (compiler).compilers;
 
-                // TODO remove `colorette` and set minimum supported webpack version is `5.101.0`
                 childStatsOptions.colors =
-                  typeof firstCompiler.webpack !== "undefined" &&
-                  typeof firstCompiler.webpack.cli !== "undefined" &&
-                  typeof firstCompiler.webpack.cli.isColorSupported ===
-                    "function"
-                    ? firstCompiler.webpack.cli.isColorSupported()
-                    : require("colorette").isColorSupported;
+                  firstCompiler.webpack.cli.isColorSupported();
               }
 
               return childStatsOptions;
@@ -133,13 +127,7 @@ function setupHooks(context) {
 
         if (typeof statsOptions.colors === "undefined") {
           const { compiler } = /** @type {{ compiler: Compiler }} */ (context);
-          // TODO remove `colorette` and set minimum supported webpack version is `5.101.0`
-          statsOptions.colors =
-            typeof compiler.webpack !== "undefined" &&
-            typeof compiler.webpack.cli !== "undefined" &&
-            typeof compiler.webpack.cli.isColorSupported === "function"
-              ? compiler.webpack.cli.isColorSupported()
-              : require("colorette").isColorSupported;
+          statsOptions.colors = compiler.webpack.cli.isColorSupported();
         }
       }
 

--- a/test/utils/setupHooks.test.js
+++ b/test/utils/setupHooks.test.js
@@ -12,6 +12,7 @@ describe("setupHooks", () => {
   const loggerInfo = jest.fn();
   const loggerWarn = jest.fn();
   const loggerError = jest.fn();
+  const colorSupport = jest.fn();
   let nextTick;
 
   const cb1 = jest.fn();
@@ -22,6 +23,11 @@ describe("setupHooks", () => {
     context = {
       options: {},
       compiler: {
+        webpack: {
+          cli: {
+            isColorSupported: colorSupport,
+          },
+        },
         hooks: {
           watchRun: {
             tap: watchRunHook,
@@ -126,12 +132,22 @@ describe("setupHooks", () => {
   it("handles multi compiler", () => {
     context.compiler.compilers = [
       {
+        webpack: {
+          cli: {
+            isColorSupported: colorSupport,
+          },
+        },
         options: {
           name: "comp1",
           stats: {},
         },
       },
       {
+        webpack: {
+          cli: {
+            isColorSupported: colorSupport,
+          },
+        },
         options: {
           name: "comp2",
           stats: {},


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

With this, we reduce the dependencies we have and use the native helper provided by webpack without a fallback.

**What kind of change does this PR introduce?**

chore

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

Yes, it introduces a breaking change that requires using a webpack version greater than or equal to 101.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
