### PR TITLE
Do not hook assetEmitted when writeToDisk is true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -229,7 +229,7 @@ function wdm(compiler, options = {}) {
 
   setupHooks(context);
 
-  if (options.writeToDisk) {
+  if (typeof options.writeToDisk === "function") {
     setupWriteToDisk(context);
   }
 

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -4056,7 +4056,7 @@ describe.each([
                 compiler.hooks.assetEmitted.taps.filter(
                   (hook) => hook.name === "DevMiddleware",
                 ),
-              ).toHaveLength(1);
+              ).toHaveLength(0);
               expect(fs.existsSync(bundlePath)).toBe(true);
 
               instance.invalidate();
@@ -4068,7 +4068,7 @@ describe.each([
                     compiler.hooks.assetEmitted.taps.filter(
                       (hook) => hook.name === "DevMiddleware",
                     ),
-                  ).toHaveLength(1);
+                  ).toHaveLength(0);
 
                   done();
                 },
@@ -4154,7 +4154,7 @@ describe.each([
               compiler.hooks.assetEmitted.taps.filter(
                 (hook) => hook.name === "DevMiddleware",
               ),
-            ).toHaveLength(1);
+            ).toHaveLength(0);
             expect(fs.existsSync(bundlePath)).toBe(true);
 
             instance.invalidate();
@@ -4166,7 +4166,7 @@ describe.each([
                   compiler.hooks.assetEmitted.taps.filter(
                     (hook) => hook.name === "DevMiddleware",
                   ),
-                ).toHaveLength(1);
+                ).toHaveLength(0);
 
                 done();
               },


### PR DESCRIPTION
**Summary**

When `writeToDisk: true` is set, files were being written to disk twice — once by webpack via its native output file system (configured by `setupOutputFileSystem`), and again by the `assetEmitted` hook set up in `setupWriteToDisk`. This caused redundant I/O for every emitted asset.

The fix changes the call site in `index.js` to only invoke `setupWriteToDisk` when `writeToDisk` is a filter function. When it is `true`, webpack handles disk writes natively and no hook is needed.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes. The existing `writeToDisk: true` tests in `middleware.test.js` already asserted on the number of `assetEmitted` taps — those assertions have been updated from `toHaveLength(1)` to `toHaveLength(0)` to reflect that `DevMiddleware` no longer taps `assetEmitted` when `writeToDisk: true`. The tests continue to verify that the bundle file is found on disk.

**Does this PR introduce a breaking change?**

No. Behaviour for end users is unchanged — files are still written to disk when `writeToDisk: true`, just without the redundant second write.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No documentation changes needed.

**Use of AI**

This PR was developed with the assistance of Claude (Anthropic). The fix and tests were generated and reviewed with AI support, in accordance with the [webpack AI policy](https://github.com/webpack/governance/blob/main/AI_POLICY.md).