### PR TITLE
fix: convert node readable to web stream in honoWrapper

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -841,6 +841,99 @@ function koaWrapper(compiler, options = {}, usePlugin = false) {
 
 wdm.koaWrapper = koaWrapper;
 
+// Convert a Node.js `Readable` into a Web `ReadableStream` ourselves so we can
+// hand it to Hono in a form `@hono/node-server` fast-paths through
+// `responseViaCache` -> `writeFromReadableStream`. Avoids Node's internal
+// `Readable.toWeb` adapter, which races on late `error`/`close` events from
+// `fs.ReadStream` and throws "Invalid state: ReadableStream already closed"
+// (notably on Windows + Node 20). All controller transitions are guarded.
+/**
+ * @param {import("fs").ReadStream} stream node readable stream
+ * @returns {ReadableStream<Uint8Array>} web readable stream
+ */
+function nodeReadableToWebStream(stream) {
+  // ReadableStream has been a global since Node 16.5 and is stable in practice
+  // since Node 18; eslint-plugin-n flags it as experimental.
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
+  return new ReadableStream({
+    start(controller) {
+      let closed = false;
+      /** @type {() => void} */
+      let cleanup;
+
+      /**
+       * @param {Buffer | string} chunk chunk
+       */
+      const onData = (chunk) => {
+        if (closed) return;
+        try {
+          controller.enqueue(
+            chunk instanceof Uint8Array ? chunk : Buffer.from(chunk),
+          );
+        } catch {
+          // Controller already closed/errored; nothing to do.
+        }
+        if (controller.desiredSize !== null && controller.desiredSize <= 0) {
+          stream.pause();
+        }
+      };
+      const onEnd = () => {
+        if (closed) return;
+        closed = true;
+        cleanup();
+        try {
+          controller.close();
+        } catch {
+          // Already closed.
+        }
+      };
+      /**
+       * @param {Error} err err
+       */
+      const onError = (err) => {
+        if (closed) return;
+        closed = true;
+        cleanup();
+        try {
+          controller.error(err);
+        } catch {
+          // Already closed/errored.
+        }
+      };
+      cleanup = () => {
+        stream.off("data", onData);
+        stream.off("end", onEnd);
+        stream.off("error", onError);
+      };
+
+      // Stream may have already finished by the time we wrap it (empty file
+      // path resolved on the `end` event in `res.stream`).
+      if (stream.readableEnded || stream.destroyed) {
+        try {
+          controller.close();
+        } catch {
+          // Already closed.
+        }
+        return;
+      }
+
+      stream.on("data", onData);
+      stream.once("end", onEnd);
+      stream.once("error", onError);
+    },
+    pull() {
+      if (typeof stream.resume === "function") {
+        stream.resume();
+      }
+    },
+    cancel(reason) {
+      if (typeof stream.destroy === "function") {
+        stream.destroy(reason instanceof Error ? reason : undefined);
+      }
+    },
+  });
+}
+
 /**
  * @template {IncomingMessage} [RequestInternal=IncomingMessage]
  * @template {ServerResponse} [ResponseInternal=ServerResponse]
@@ -964,7 +1057,10 @@ function honoWrapper(compiler, options = {}, usePlugin = false) {
                 return;
               }
 
-              body = stream;
+              // Wrap as a Web ReadableStream so `@hono/node-server` takes its
+              // fast path and Node's internal `Readable.toWeb` adapter is not
+              // involved (it races on late `error`/`close` from fs streams).
+              body = nodeReadableToWebStream(stream);
               isFinished = true;
 
               resolve();

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const memfs = require("memfs");
 const mime = require("mime-types");
 
 const middleware = require("./middleware");
+const { nodeReadableToWebStream } = require("./utils");
 
 const noop = () => {};
 
@@ -840,99 +841,6 @@ function koaWrapper(compiler, options = {}, usePlugin = false) {
 }
 
 wdm.koaWrapper = koaWrapper;
-
-// Convert a Node.js `Readable` into a Web `ReadableStream` ourselves so we can
-// hand it to Hono in a form `@hono/node-server` fast-paths through
-// `responseViaCache` -> `writeFromReadableStream`. Avoids Node's internal
-// `Readable.toWeb` adapter, which races on late `error`/`close` events from
-// `fs.ReadStream` and throws "Invalid state: ReadableStream already closed"
-// (notably on Windows + Node 20). All controller transitions are guarded.
-/**
- * @param {import("fs").ReadStream} stream node readable stream
- * @returns {ReadableStream<Uint8Array>} web readable stream
- */
-function nodeReadableToWebStream(stream) {
-  // ReadableStream has been a global since Node 16.5 and is stable in practice
-  // since Node 18; eslint-plugin-n flags it as experimental.
-  // eslint-disable-next-line n/no-unsupported-features/node-builtins
-  return new ReadableStream({
-    start(controller) {
-      let closed = false;
-      /** @type {() => void} */
-      let cleanup;
-
-      /**
-       * @param {Buffer | string} chunk chunk
-       */
-      const onData = (chunk) => {
-        if (closed) return;
-        try {
-          controller.enqueue(
-            chunk instanceof Uint8Array ? chunk : Buffer.from(chunk),
-          );
-        } catch {
-          // Controller already closed/errored; nothing to do.
-        }
-        if (controller.desiredSize !== null && controller.desiredSize <= 0) {
-          stream.pause();
-        }
-      };
-      const onEnd = () => {
-        if (closed) return;
-        closed = true;
-        cleanup();
-        try {
-          controller.close();
-        } catch {
-          // Already closed.
-        }
-      };
-      /**
-       * @param {Error} err err
-       */
-      const onError = (err) => {
-        if (closed) return;
-        closed = true;
-        cleanup();
-        try {
-          controller.error(err);
-        } catch {
-          // Already closed/errored.
-        }
-      };
-      cleanup = () => {
-        stream.off("data", onData);
-        stream.off("end", onEnd);
-        stream.off("error", onError);
-      };
-
-      // Stream may have already finished by the time we wrap it (empty file
-      // path resolved on the `end` event in `res.stream`).
-      if (stream.readableEnded || stream.destroyed) {
-        try {
-          controller.close();
-        } catch {
-          // Already closed.
-        }
-        return;
-      }
-
-      stream.on("data", onData);
-      stream.once("end", onEnd);
-      stream.once("error", onError);
-    },
-    pull() {
-      if (typeof stream.resume === "function") {
-        stream.resume();
-      }
-    },
-    cancel(reason) {
-      if (typeof stream.destroy === "function") {
-        stream.destroy(reason instanceof Error ? reason : undefined);
-      }
-    },
-  });
-}
 
 /**
  * @template {IncomingMessage} [RequestInternal=IncomingMessage]

--- a/src/utils.js
+++ b/src/utils.js
@@ -578,6 +578,10 @@ function setState(res, name, value) {
 // `Readable.toWeb` adapter, which races on late `error`/`close` events from
 // `fs.ReadStream` and throws "Invalid state: ReadableStream already closed"
 // (notably on Windows + Node 20). All controller transitions are guarded.
+// TODO remove this helper (and its use in honoWrapper) when the upstream race
+// is fixed and the minimum supported Node version no longer reproduces it:
+//   - https://github.com/honojs/node-server/issues/233
+//   - https://github.com/honojs/node-server/pull/299
 /**
  * @param {import("fs").ReadStream} stream node readable stream
  * @returns {ReadableStream<Uint8Array>} web readable stream

--- a/src/utils.js
+++ b/src/utils.js
@@ -572,6 +572,99 @@ function setState(res, name, value) {
   (res.locals)[name] = value;
 }
 
+// Convert a Node.js `Readable` into a Web `ReadableStream` ourselves so we can
+// hand it to Hono in a form `@hono/node-server` fast-paths through
+// `responseViaCache` -> `writeFromReadableStream`. Avoids Node's internal
+// `Readable.toWeb` adapter, which races on late `error`/`close` events from
+// `fs.ReadStream` and throws "Invalid state: ReadableStream already closed"
+// (notably on Windows + Node 20). All controller transitions are guarded.
+/**
+ * @param {import("fs").ReadStream} stream node readable stream
+ * @returns {ReadableStream<Uint8Array>} web readable stream
+ */
+function nodeReadableToWebStream(stream) {
+  // ReadableStream has been a global since Node 16.5 and is stable in practice
+  // since Node 18; eslint-plugin-n flags it as experimental.
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
+  return new ReadableStream({
+    start(controller) {
+      let closed = false;
+      /** @type {() => void} */
+      let cleanup;
+
+      /**
+       * @param {Buffer | string} chunk chunk
+       */
+      const onData = (chunk) => {
+        if (closed) return;
+        try {
+          controller.enqueue(
+            chunk instanceof Uint8Array ? chunk : Buffer.from(chunk),
+          );
+        } catch {
+          // Controller already closed/errored; nothing to do.
+        }
+        if (controller.desiredSize !== null && controller.desiredSize <= 0) {
+          stream.pause();
+        }
+      };
+      const onEnd = () => {
+        if (closed) return;
+        closed = true;
+        cleanup();
+        try {
+          controller.close();
+        } catch {
+          // Already closed.
+        }
+      };
+      /**
+       * @param {Error} err err
+       */
+      const onError = (err) => {
+        if (closed) return;
+        closed = true;
+        cleanup();
+        try {
+          controller.error(err);
+        } catch {
+          // Already closed/errored.
+        }
+      };
+      cleanup = () => {
+        stream.off("data", onData);
+        stream.off("end", onEnd);
+        stream.off("error", onError);
+      };
+
+      // Stream may have already finished by the time we wrap it (empty file
+      // path resolved on the `end` event in `res.stream`).
+      if (stream.readableEnded || stream.destroyed) {
+        try {
+          controller.close();
+        } catch {
+          // Already closed.
+        }
+        return;
+      }
+
+      stream.on("data", onData);
+      stream.once("end", onEnd);
+      stream.once("error", onError);
+    },
+    pull() {
+      if (typeof stream.resume === "function") {
+        stream.resume();
+      }
+    },
+    cancel(reason) {
+      if (typeof stream.destroy === "function") {
+        stream.destroy(reason instanceof Error ? reason : undefined);
+      }
+    },
+  });
+}
+
 module.exports = {
   createReadStreamOrReadFile,
   destroyStream,
@@ -589,6 +682,7 @@ module.exports = {
   getValueContentRangeHeader,
   initState,
   memorize,
+  nodeReadableToWebStream,
   parseHttpDate,
   parseTokenList,
   pipe,

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -266,6 +266,13 @@ export function memorize<T>(
     | undefined,
   callback?: ((value: T) => T) | undefined,
 ): FunctionReturning<T>;
+/**
+ * @param {import("fs").ReadStream} stream node readable stream
+ * @returns {ReadableStream<Uint8Array>} web readable stream
+ */
+export function nodeReadableToWebStream(
+  stream: import("fs").ReadStream,
+): ReadableStream<Uint8Array>;
 /** @typedef {import("fs").Stats} Stats */
 /** @typedef {import("fs").ReadStream} ReadStream */
 /**


### PR DESCRIPTION
Wrap the Node fs.ReadStream in a Web ReadableStream we control before
handing it to Hono. This routes the response through @hono/node-server's
responseViaCache fast path (writeFromReadableStream) and bypasses Node's
internal Readable.toWeb adapter, whose late error/close propagation
caused intermittent "TypeError: Invalid state: ReadableStream already
closed" on Windows + Node 20.

All controller transitions are guarded so duplicate end/error events
from the underlying fs stream cannot crash the Web stream controller.