### PR TITLE
chore(deps): replace `on-finished` with Node.js built-in `stream.finished

### DIFF
--- a/.changeset/plenty-pans-clap.md
+++ b/.changeset/plenty-pans-clap.md
@@ -1,0 +1,5 @@
+---
+"webpack-dev-middleware": patch
+---
+
+Replace the `on-finished` dependency with Node.js built-in `stream.finished`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "memfs": "^4.56.10",
         "mime-types": "^3.0.2",
-        "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
         "schema-utils": "^4.3.3"
       },
@@ -28,7 +27,6 @@
         "@types/express": "^5.0.2",
         "@types/mime-types": "^3.0.1",
         "@types/node": "^22.3.0",
-        "@types/on-finished": "^2.3.4",
         "babel-jest": "^30.1.2",
         "connect": "^3.7.0",
         "cspell": "^10.0.0",
@@ -5243,16 +5241,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/on-finished": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@types/on-finished/-/on-finished-2.3.5.tgz",
-      "integrity": "sha512-XUaCx9tVIC577KsOZxKbnvGlyPt2ogNXQEq/bOQpAfPwH9sH0FbzrRsK1961jpjKlK5V+Owmw55dVjukWhwH0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/qs": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
@@ -8180,6 +8168,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -15170,6 +15159,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   "dependencies": {
     "memfs": "^4.56.10",
     "mime-types": "^3.0.2",
-    "on-finished": "^2.4.1",
     "range-parser": "^1.2.1",
     "schema-utils": "^4.3.3"
   },
@@ -65,7 +64,6 @@
     "@types/express": "^5.0.2",
     "@types/mime-types": "^3.0.1",
     "@types/node": "^22.3.0",
-    "@types/on-finished": "^2.3.4",
     "babel-jest": "^30.1.2",
     "connect": "^3.7.0",
     "cspell": "^10.0.0",

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,8 +1,8 @@
 const path = require("node:path");
 const querystring = require("node:querystring");
+const { finished } = require("node:stream");
 
 const mime = require("mime-types");
-const onFinishedStream = require("on-finished");
 
 const {
   createReadStreamOrReadFile,
@@ -1122,7 +1122,7 @@ function wrapper(context) {
 
       if (outgoing) {
         // Response finished, cleanup
-        onFinishedStream(outgoing, (err) => {
+        finished(outgoing, (err) => {
           if (err) {
             context.logger.error("Stream error:", err);
           }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Basically, we don't need `on-finished`. Since the next major version of `on-finished` will use `finished` under the hood, this package doesn't need everything that `on-finished` provides—or will provide.


**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->