### PR TITLE
feat(plugin): implement close method for plugin mode handling

### DIFF
--- a/.changeset/plugin-mode-close.md
+++ b/.changeset/plugin-mode-close.md
@@ -1,0 +1,5 @@
+---
+"webpack-dev-middleware": patch
+---
+
+Fixed a crash when calling `close()` in plugin mode (`isPlugin = true`). Since the host (webpack-cli, webpack-dev-server, etc.) owns `compiler.watch()`, the middleware has no `watching` of its own to close, so `close()` now just calls the callback instead of throwing.

--- a/src/index.js
+++ b/src/index.js
@@ -606,6 +606,9 @@ function wdm(compiler, options = {}, isPlugin = false) {
     // For plugin usage the host (webpack-cli, webpack-dev-server, etc.) owns `compiler.watch()`,
     // so there is no `watching` of our own to close (`compiler.close()` on the host handles it)
     if (!filledContext.watching) {
+      filledContext.logger.warn(
+        "The `close` method was called, but there is no own `watching` instance to close. When using the middleware as a plugin, the host owns watching, so use `compiler.close()` instead.",
+      );
       callback(null);
       return;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -597,10 +597,19 @@ function wdm(compiler, options = {}, isPlugin = false) {
   instance.invalidate = (callback = noop) => {
     middleware.ready(filledContext, callback);
 
+    // TODO for plugin usage (`isPlugin = true`) `watching` is `undefined` and this throws —
+    // invalidate the host's `compiler.watching` (each child's one for a `MultiCompiler`) instead
     filledContext.watching.invalidate();
   };
 
   instance.close = (callback = noop) => {
+    // For plugin usage the host (webpack-cli, webpack-dev-server, etc.) owns `compiler.watch()`,
+    // so there is no `watching` of our own to close (`compiler.close()` on the host handles it)
+    if (!filledContext.watching) {
+      callback(null);
+      return;
+    }
+
     filledContext.watching.close(callback);
   };
 

--- a/test/__snapshots__/pluginMode.test.js.snap.webpack5
+++ b/test/__snapshots__/pluginMode.test.js.snap.webpack5
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`plugin mode close method should not close the watching owned by the host: warning 1`] = `"The \`close\` method was called, but there is no own \`watching\` instance to close. When using the middleware as a plugin, the host owns watching, so use \`compiler.close()\` instead."`;
+
+exports[`plugin mode close method should not throw and call the callback when the host is not watching: warning 1`] = `"The \`close\` method was called, but there is no own \`watching\` instance to close. When using the middleware as a plugin, the host owns watching, so use \`compiler.close()\` instead."`;

--- a/test/pluginMode.test.js
+++ b/test/pluginMode.test.js
@@ -1,0 +1,39 @@
+import middleware from "../src";
+
+import webpackConfig from "./fixtures/webpack.config";
+import getCompiler from "./helpers/getCompiler";
+
+jest.spyOn(globalThis.console, "log").mockImplementation();
+
+// When used as a plugin (`isPlugin = true`) the host (webpack-cli,
+// webpack-dev-server, etc.) owns `compiler.watch()`, so the middleware has no
+// `watching` of its own
+describe("plugin mode", () => {
+  describe("close method", () => {
+    it("should not throw and call the callback when the host is not watching", (done) => {
+      const compiler = getCompiler(webpackConfig);
+      const instance = middleware(compiler, {}, true);
+
+      instance.close((error) => {
+        expect(error).toBeNull();
+
+        done();
+      });
+    });
+
+    it("should not close the watching owned by the host", (done) => {
+      const compiler = getCompiler(webpackConfig);
+      const watching = compiler.watch({}, () => {});
+      const instance = middleware(compiler, {}, true);
+
+      instance.waitUntilValid(() => {
+        instance.close((error) => {
+          expect(error).toBeNull();
+          expect(watching.closed).toBe(false);
+
+          watching.close(done);
+        });
+      });
+    });
+  });
+});

--- a/test/pluginMode.test.js
+++ b/test/pluginMode.test.js
@@ -13,9 +13,14 @@ describe("plugin mode", () => {
     it("should not throw and call the callback when the host is not watching", (done) => {
       const compiler = getCompiler(webpackConfig);
       const instance = middleware(compiler, {}, true);
+      const warnSpy = jest
+        .spyOn(instance.context.logger, "warn")
+        .mockImplementation();
 
       instance.close((error) => {
         expect(error).toBeNull();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0][0]).toMatchSnapshot("warning");
 
         done();
       });
@@ -25,11 +30,16 @@ describe("plugin mode", () => {
       const compiler = getCompiler(webpackConfig);
       const watching = compiler.watch({}, () => {});
       const instance = middleware(compiler, {}, true);
+      const warnSpy = jest
+        .spyOn(instance.context.logger, "warn")
+        .mockImplementation();
 
       instance.waitUntilValid(() => {
         instance.close((error) => {
           expect(error).toBeNull();
           expect(watching.closed).toBe(false);
+          expect(warnSpy).toHaveBeenCalledTimes(1);
+          expect(warnSpy.mock.calls[0][0]).toMatchSnapshot("warning");
 
           watching.close(done);
         });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

This is just an improvement. As for the rest, I'm not sure how much it would help or whether you actually want to do it.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, defensive change to shutdown behavior in plugin mode with new tests; no change to standalone watching teardown.
> 
> **Overview**
> **Fixes a crash** when `close()` is called while the middleware is used as a plugin (`isPlugin = true`). In that mode the host owns `compiler.watch()`, so `context.watching` is never set; `close()` used to throw when it tried to call `watching.close()`.
> 
> `close()` now checks for a missing `watching` instance, logs a warning pointing callers at `compiler.close()`, invokes the callback with no error, and returns without touching the host’s watch session. Plugin-mode tests cover both idle and host-watching cases, with snapshot assertions on the warning text. A patch changeset records the fix.
> 
> A **TODO** on `invalidate()` notes the same `watching` gap still exists there and is not addressed in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c82442d7a4712fb225f17d99c22c4b3e6f72e6b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->