### PR TITLE
feat(client): add disconnect() to close the SSE connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,10 @@ hotClient.useCustomOverlay({
 // Connect manually when `autoConnect=false`. Accepts the same option keys as
 // the query-string API above.
 hotClient.setOptionsAndConnect({ path: "/__hmr" });
+
+// Close the SSE connection and stop reconnecting (e.g. before tearing the
+// page down). A later `setOptionsAndConnect` call opens a fresh connection.
+hotClient.disconnect();
 ```
 
 ## API

--- a/client-src/globals.d.ts
+++ b/client-src/globals.d.ts
@@ -20,6 +20,7 @@ interface ClientReporter {
 
 interface EventSourceWrapper {
   addMessageListener(fn: (event: { data: string }) => void): void;
+  close(): void;
 }
 
 interface Window {

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -78,7 +78,7 @@ function setOverrides(overrides) {
  */
 
 /**
- * @returns {{ addMessageListener: (fn: MessageListener) => void }} event source wrapper
+ * @returns {{ addMessageListener: (fn: MessageListener) => void, close: () => void }} event source wrapper
  */
 function createEventSourceWrapper() {
   /** @type {EventSource} */

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -104,9 +104,17 @@ function createEventSourceWrapper() {
     }
   };
 
-  const handleDisconnect = () => {
+  /**
+   * Close the connection and stop the activity timer without scheduling a
+   * reconnection.
+   */
+  const close = () => {
     clearInterval(timer);
     source.close();
+  };
+
+  const handleDisconnect = () => {
+    close();
     setTimeout(init, /** @type {number} */ (options.timeout));
   };
 
@@ -134,6 +142,7 @@ function createEventSourceWrapper() {
     addMessageListener(fn) {
       listeners.push(fn);
     },
+    close,
   };
 }
 
@@ -177,6 +186,20 @@ function connect() {
 export function setOptionsAndConnect(overrides) {
   setOverrides(overrides);
   connect();
+}
+
+/**
+ * Close the SSE connection for the current path and stop reconnecting. A
+ * later `setOptionsAndConnect` call opens a fresh connection.
+ */
+export function disconnect() {
+  const path = /** @type {string} */ (options.path);
+  const wrappers = window[WRAPPER_KEY];
+
+  if (wrappers && wrappers[path]) {
+    wrappers[path].close();
+    delete wrappers[path];
+  }
 }
 
 // eslint-disable-next-line jsdoc/reject-any-type

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -597,6 +597,32 @@ describe("client", () => {
       jest.advanceTimersByTime(20 * 1000);
       expect(EventSourceStub.instances).toHaveLength(2);
     });
+
+    it("disconnect() closes the connection and does not reconnect", () => {
+      jest.useFakeTimers({ doNotFake: ["nextTick"] });
+      delete globalThis.__wdmEventSourceWrapper;
+      EventSourceStub.instances.length = 0;
+      client = loadClient();
+
+      const [first] = EventSourceStub.instances;
+      client.disconnect();
+
+      expect(first.closed).toBe(true);
+      // Neither the watchdog nor a reconnect timer may re-open it.
+      jest.advanceTimersByTime(60 * 1000);
+      expect(EventSourceStub.instances).toHaveLength(1);
+    });
+
+    it("disconnect() drops the cached wrapper so a new connect starts fresh", () => {
+      client.disconnect();
+      expect(
+        globalThis.__wdmEventSourceWrapper["/__webpack_hmr"],
+      ).toBeUndefined();
+
+      client.setOptionsAndConnect({});
+      expect(EventSourceStub.instances).toHaveLength(2);
+      expect(EventSourceStub.lastInstance().closed).toBe(false);
+    });
   });
 
   describe("with logging option", () => {


### PR DESCRIPTION
Expose a way to close the EventSource for the current path and stop the reconnection watchdog (e.g. before tearing the page down). The cached wrapper is dropped so a later setOptionsAndConnect() opens a fresh connection.

Ref webpack/webpack-hot-middleware#367

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->