### PR TITLE
feat(hot): include the changed file in the building event

### DIFF
--- a/client-src/index.js
+++ b/client-src/index.js
@@ -205,7 +205,7 @@ export function disconnect() {
 // eslint-disable-next-line jsdoc/reject-any-type
 /** @typedef {any} EXPECTED_ANY */
 
-/** @typedef {{ name?: string, errors: string[], warnings: string[], hash: string, time?: number, action?: string }} HMRPayload */
+/** @typedef {{ name?: string, errors: string[], warnings: string[], hash: string, time?: number, action?: string, file?: string }} HMRPayload */
 
 /**
  * @returns {{
@@ -291,7 +291,11 @@ let subscribeAllHandler;
 function processMessage(obj) {
   switch (obj.action) {
     case "building": {
-      log.info(`bundle ${obj.name ? `'${obj.name}' ` : ""}rebuilding`);
+      log.info(
+        `bundle ${obj.name ? `'${obj.name}' ` : ""}rebuilding${
+          obj.file ? ` (${obj.file} changed)` : ""
+        }`,
+      );
       break;
     }
     case "built":

--- a/src/hot.js
+++ b/src/hot.js
@@ -20,6 +20,7 @@
 /**
  * @typedef {object} Payload
  * @property {string} action action
+ * @property {string=} file file that invalidated the compilation
  * @property {string=} name name
  * @property {number=} time time
  * @property {string=} hash hash
@@ -262,12 +263,22 @@ function createHot(compiler, userOptions) {
   let latestStats = null;
   let closed = false;
 
-  const onInvalid = () => {
+  /** @param {string | null=} fileName file that triggered the rebuild */
+  const onInvalid = (fileName) => {
     if (closed) return;
 
     latestStats = null;
 
-    eventStream.publish({ action: "building" });
+    /** @type {{ action: string, file?: string }} */
+    const payload = { action: "building" };
+
+    // The invalid hook reports which file changed — forward it so clients
+    // can show what triggered the rebuild.
+    if (typeof fileName === "string" && fileName) {
+      payload.file = fileName;
+    }
+
+    eventStream.publish(payload);
   };
 
   /** @param {Stats | MultiStats} statsResult stats result */

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -159,6 +159,17 @@ describe("client", () => {
       expect(processUpdate).toHaveBeenCalledTimes(1);
     });
 
+    it("logs the changed file on building messages", () => {
+      EventSourceStub.lastInstance().onmessage(
+        makeMessage({ action: "building", file: "/src/index.js" }),
+      );
+      expect(
+        console.info.mock.calls.some(([msg]) =>
+          msg.includes("rebuilding (/src/index.js changed)"),
+        ),
+      ).toBe(true);
+    });
+
     it("calls subscribeAll handler on default messages", () => {
       const spy = jest.fn();
       client.subscribeAll(spy);

--- a/test/helpers/sse.js
+++ b/test/helpers/sse.js
@@ -3,6 +3,7 @@ import http from "node:http";
 /**
  * @typedef {object} SseEvent
  * @property {string=} action event action (building/built/sync/custom)
+ * @property {string=} file file that invalidated the compilation
  * @property {string=} name compilation name
  * @property {string=} hash compilation hash
  * @property {number=} time build time in ms

--- a/test/hot.test.js
+++ b/test/hot.test.js
@@ -27,8 +27,8 @@ function makeFakeCompiler(logger = noopLogger) {
       done: { tap: (_name, fn) => doneTaps.push(fn) },
     },
     getInfrastructureLogger: () => logger,
-    emitInvalid() {
-      for (const fn of invalidTaps) fn();
+    emitInvalid(fileName) {
+      for (const fn of invalidTaps) fn(fileName);
     },
     emitDone(stats) {
       for (const fn of doneTaps) fn(stats);
@@ -311,6 +311,38 @@ describe("createHot", () => {
           w.includes('"action":"custom-thing"') && w.includes('"payload":42'),
       ),
     ).toBe(true);
+
+    hot.close();
+  });
+
+  it("includes the changed file in the building payload", () => {
+    const compiler = makeFakeCompiler();
+    const hot = createHot(compiler, {});
+    const { writes } = attachClient({ handler: hot.handle });
+
+    compiler.emitInvalid("/src/index.js");
+
+    expect(
+      writes.some(
+        (w) =>
+          w.includes('"action":"building"') &&
+          w.includes('"file":"/src/index.js"'),
+      ),
+    ).toBe(true);
+
+    hot.close();
+  });
+
+  it("omits the file field when the invalid hook reports none", () => {
+    const compiler = makeFakeCompiler();
+    const hot = createHot(compiler, {});
+    const { writes } = attachClient({ handler: hot.handle });
+
+    compiler.emitInvalid();
+
+    const building = writes.find((w) => w.includes('"action":"building"'));
+    expect(building).toBeDefined();
+    expect(building).not.toContain('"file"');
 
     hot.close();
   });

--- a/types/hot.d.ts
+++ b/types/hot.d.ts
@@ -60,6 +60,7 @@ declare const HOT_DEFAULT_HEARTBEAT: number;
 /**
  * @typedef {object} Payload
  * @property {string} action action
+ * @property {string=} file file that invalidated the compilation
  * @property {string=} name name
  * @property {number=} time time
  * @property {string=} hash hash
@@ -158,6 +159,10 @@ type Payload = {
    * action
    */
   action: string;
+  /**
+   * file that invalidated the compilation
+   */
+  file?: string | undefined;
   /**
    * name
    */


### PR DESCRIPTION
The compiler's invalid hook reports which file invalidated the compilation. Forward it as an optional `file` field on the `building` payload and log it in the client, so users can see what triggered a rebuild.

Ref webpack/webpack-hot-middleware#173

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->