### PR TITLE
feat(hot): add a building indicator with optional compilation progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,13 @@ Default: `10000`
 
 Heartbeat interval (in milliseconds) used to keep the SSE connection alive when no compilation events are produced.
 
+#### `hot.progress`
+
+Type: `Boolean`
+Default: `undefined`
+
+Publish compilation progress events (`{ action: "progress", percent, message }`) to the clients using webpack's `ProgressPlugin`. The bundled client shows the percentage in its building badge (see the client `progress` option).
+
 #### `hot.statsOptions`
 
 Type: `Boolean | Object`
@@ -384,6 +391,7 @@ entry: [
 |      `logging`      |     `string`      |     `"info"`     | Logger level — one of `"none"`, `"error"`, `"warn"`, `"info"`, `"log"`, `"verbose"`. Uses webpack's runtime logger.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 |       `name`        |     `string`      |       `""`       | Restrict updates to a specific compilation name (useful with multi-compiler).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 |    `autoConnect`    |     `boolean`     |      `true`      | Connect on load; set to `false` and call `setOptionsAndConnect()` manually.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+|     `progress`      |     `boolean`     |      `true`      | Show a small badge in the page while a rebuild is in progress (with the compilation percentage when the server enables `hot.progress`). Set to `false` to disable.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | `dynamicPublicPath` |     `boolean`     |     `false`      | Prefix `path` with `__webpack_public_path__` at runtime. The leading slash of `path` is stripped and no other normalization is applied, so the public path should end with `/`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 
 ### Programmatic API
@@ -439,6 +447,16 @@ const overlay = configureOverlay({
 
 overlay.showProblems("errors", ["Something broke"]);
 overlay.clear();
+```
+
+The building indicator is exposed the same way:
+
+```js
+import { hide, show } from "webpack-dev-middleware/client/indicator";
+
+show("Rebuilding…"); // pulsing dot
+show("Rebuilding… 42%", 42); // progress ring
+hide();
 ```
 
 ## API

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -1,5 +1,6 @@
 /* global __resourceQuery, __webpack_public_path__ */
 
+import * as indicator from "./indicator.js";
 import configureOverlay from "./overlay.js";
 import applyUpdate from "./process-update.js";
 import { log, setLogLevel } from "./utils/log.js";
@@ -31,6 +32,7 @@ import stripAnsi from "./utils/strip-ansi.js";
  * @property {LogLevel} logging logger level
  * @property {string} name limit updates to this compilation name
  * @property {boolean} autoConnect connect immediately when the entry runs
+ * @property {boolean} progress show a small badge while a rebuild is in progress
  */
 
 /** @type {ClientOptions} */
@@ -42,6 +44,7 @@ const options = {
   logging: "info",
   name: "",
   autoConnect: true,
+  progress: true,
 };
 
 /**
@@ -110,6 +113,10 @@ function setOverrides(overrides) {
   }
   if (overrides.name) {
     options.name = overrides.name;
+  }
+
+  if (overrides.progress) {
+    options.progress = overrides.progress !== "false";
   }
 
   if (overrides.dynamicPublicPath) {
@@ -253,7 +260,7 @@ export function disconnect() {
 // eslint-disable-next-line jsdoc/reject-any-type
 /** @typedef {any} EXPECTED_ANY */
 
-/** @typedef {{ name?: string, errors: string[], warnings: string[], hash: string, time?: number, action?: string, file?: string }} HMRPayload */
+/** @typedef {{ name?: string, errors: string[], warnings: string[], hash: string, time?: number, action?: string, file?: string, percent?: number, message?: string }} HMRPayload */
 
 /**
  * @returns {{
@@ -420,10 +427,25 @@ function processMessage(obj) {
           obj.file ? ` (${obj.file} changed)` : ""
         }`,
       );
+      if (options.progress && typeof document !== "undefined") {
+        indicator.show(obj.file ? `Rebuilding… (${obj.file})` : undefined);
+      }
+      break;
+    }
+    case "progress": {
+      if (options.progress && typeof document !== "undefined") {
+        indicator.show(
+          `Rebuilding… ${obj.percent}%${obj.message ? ` (${obj.message})` : ""}`,
+          obj.percent,
+        );
+      }
       break;
     }
     case "built":
     case "sync": {
+      if (options.progress && typeof document !== "undefined") {
+        indicator.hide();
+      }
       if (obj.action === "built") {
         log.info(
           `bundle ${obj.name ? `'${obj.name}' ` : ""}rebuilt in ${obj.time}ms`,

--- a/client-src/indicator.js
+++ b/client-src/indicator.js
@@ -1,0 +1,172 @@
+// Small badge shown while a rebuild is in progress. It lives in a shadow root
+// so page styles cannot affect it; styles go through the CSSOM and SVG
+// presentation attributes, which a strict `style-src` CSP allows.
+
+import theme from "./theme.js";
+
+const INDICATOR_ID = "webpack-dev-middleware-building-indicator";
+const SVG_NS = "http://www.w3.org/2000/svg";
+// Circumference of the progress ring (r = 6).
+const RING_LENGTH = 2 * Math.PI * 6;
+
+/** @type {HTMLElement | null} */
+let host = null;
+/** @type {HTMLElement | null} */
+let label = null;
+/** @type {HTMLElement | null} */
+let dot = null;
+/** @type {SVGSVGElement | null} */
+let ring = null;
+/** @type {SVGCircleElement | null} */
+let ringValue = null;
+
+// eslint-disable-next-line jsdoc/reject-any-type
+/** @typedef {any} EXPECTED_ANY */
+
+/**
+ * @param {EXPECTED_ANY} element element
+ * @param {Record<string, string | number>} style style map
+ */
+function applyStyle(element, style) {
+  for (const key of Object.keys(style)) {
+    element.style[key] = style[key];
+  }
+}
+
+/**
+ * Create (or reuse) the indicator host element.
+ */
+function ensureIndicator() {
+  if (host && host.parentNode) {
+    return;
+  }
+
+  if (!document.body) {
+    return;
+  }
+
+  host = document.createElement("div");
+  host.id = INDICATOR_ID;
+  applyStyle(host, {
+    position: "fixed",
+    right: "16px",
+    bottom: "16px",
+    zIndex: 9999,
+    pointerEvents: "none",
+  });
+
+  const root = host.attachShadow({ mode: "open" });
+
+  const badge = document.createElement("div");
+  applyStyle(badge, {
+    display: "flex",
+    alignItems: "center",
+    gap: "8px",
+    background: theme.panelTranslucent,
+    color: theme.text,
+    fontFamily: "Menlo, Consolas, 'Courier New', monospace",
+    fontSize: "12px",
+    padding: "6px 12px",
+    borderRadius: "16px",
+    boxShadow: "0 2px 12px rgba(0,0,0,0.35)",
+  });
+
+  // Indeterminate mode: a pulsing dot.
+  dot = document.createElement("span");
+  applyStyle(dot, {
+    width: "8px",
+    height: "8px",
+    borderRadius: "50%",
+    background: theme.accent,
+  });
+
+  // Pulse through the Web Animations API — no <style> element involved.
+  if (typeof dot.animate === "function") {
+    dot.animate([{ opacity: 1 }, { opacity: 0.2 }, { opacity: 1 }], {
+      duration: 1000,
+      iterations: Number.POSITIVE_INFINITY,
+    });
+  }
+
+  // Determinate mode: a progress ring drawn with SVG presentation attributes.
+  ring = document.createElementNS(SVG_NS, "svg");
+  ring.setAttribute("viewBox", "0 0 16 16");
+  applyStyle(ring, { width: "14px", height: "14px", display: "none" });
+
+  const track = document.createElementNS(SVG_NS, "circle");
+  track.setAttribute("cx", "8");
+  track.setAttribute("cy", "8");
+  track.setAttribute("r", "6");
+  track.setAttribute("fill", "none");
+  track.setAttribute("stroke", "rgba(255,255,255,0.25)");
+  track.setAttribute("stroke-width", "2.5");
+
+  ringValue = document.createElementNS(SVG_NS, "circle");
+  ringValue.setAttribute("cx", "8");
+  ringValue.setAttribute("cy", "8");
+  ringValue.setAttribute("r", "6");
+  ringValue.setAttribute("fill", "none");
+  ringValue.setAttribute("stroke", theme.accent);
+  ringValue.setAttribute("stroke-width", "2.5");
+  ringValue.setAttribute("stroke-linecap", "round");
+  ringValue.setAttribute("stroke-dasharray", String(RING_LENGTH));
+  ringValue.setAttribute("stroke-dashoffset", String(RING_LENGTH));
+  // Start the ring at 12 o'clock.
+  ringValue.setAttribute("transform", "rotate(-90 8 8)");
+
+  ring.append(track, ringValue);
+
+  label = document.createElement("span");
+  badge.append(dot, ring, label);
+  root.append(badge);
+  document.body.append(host);
+}
+
+/**
+ * Show the indicator (idempotent). With a percent the badge renders a
+ * progress ring; without one it renders a pulsing dot.
+ * @param {string=} text label text
+ * @param {number=} percent compilation progress (0-100)
+ */
+export function show(text, percent) {
+  ensureIndicator();
+
+  if (!label) {
+    return;
+  }
+
+  label.textContent = text || "Rebuilding…";
+
+  const determinate = typeof percent === "number";
+
+  /** @type {HTMLElement} */ (dot).style.display = determinate
+    ? "none"
+    : "inline-block";
+  /** @type {SVGSVGElement} */ (ring).style.display = determinate
+    ? "block"
+    : "none";
+
+  if (determinate) {
+    const clamped = Math.min(100, Math.max(0, percent));
+
+    /** @type {SVGCircleElement} */ (ringValue).setAttribute(
+      "stroke-dashoffset",
+      String(RING_LENGTH * (1 - clamped / 100)),
+    );
+  }
+}
+
+/**
+ * Remove the indicator from the page.
+ */
+export function hide() {
+  if (host && host.parentNode) {
+    host.remove();
+  }
+
+  host = null;
+  label = null;
+  dot = null;
+  ring = null;
+  ringValue = null;
+}

--- a/client-src/overlay.js
+++ b/client-src/overlay.js
@@ -1,5 +1,7 @@
 import ansiHTML from "ansi-html-community";
 
+import theme from "./theme.js";
+
 // eslint-disable-next-line jsdoc/reject-any-type
 /** @typedef {any} EXPECTED_ANY */
 
@@ -51,16 +53,15 @@ const backdropStyles = {
   height: "100vh",
   border: "none",
   zIndex: 9999,
-  // webpack "Outer Space" (#2B3A42), translucent.
-  background: "rgba(43,58,66,0.72)",
+  background: theme.backdrop,
 };
 
 /** @type {Record<string, string | number>} */
 const styles = {
   // Dark panel; the top accent bar color is set per problem type in showProblems.
   position: "relative",
-  background: "#101619",
-  color: "#f2f2f2",
+  background: theme.panel,
+  color: theme.text,
   lineHeight: "1.6",
   whiteSpace: "pre-wrap",
   fontFamily: "Menlo, Consolas, 'Courier New', monospace",
@@ -99,7 +100,7 @@ const closeButtonStyles = {
   right: "12px",
   border: "none",
   background: "transparent",
-  color: "#999999",
+  color: theme.muted,
   fontSize: "22px",
   lineHeight: "1",
   cursor: "pointer",
@@ -247,7 +248,7 @@ function highlightFilePath(html) {
     (match, filePath, location) => {
       if (!location) {
         return (
-          '<span style="color:#8dd6f9; text-decoration:underline; ' +
+          `<span style="color:${theme.accent}; text-decoration:underline; ` +
           `text-underline-offset:2px;">${match}</span>`
         );
       }
@@ -256,7 +257,7 @@ function highlightFilePath(html) {
         const position = location.trim().replace(/^:/, "");
 
         return (
-          '<span style="color:#8dd6f9; cursor:pointer; ' +
+          `<span style="color:${theme.accent}; cursor:pointer; ` +
           'text-decoration:underline; text-underline-offset:2px;" ' +
           `data-open-file="${filePath}:${position}" ` +
           'title="Click to open in your editor">' +
@@ -264,7 +265,7 @@ function highlightFilePath(html) {
         );
       }
 
-      return `<span style="color:#8dd6f9;">${filePath}</span>${location}\n`;
+      return `<span style="color:${theme.accent};">${filePath}</span>${location}\n`;
     },
   );
 }
@@ -282,7 +283,7 @@ function linkify(html) {
     const href = url.slice(0, url.length - cut.length);
     return (
       `<a href="${href}" target="_blank" rel="noopener noreferrer" ` +
-      `style="color:#8dd6f9;">${href}</a>${cut}`
+      `style="color:${theme.accent};">${href}</a>${cut}`
     );
   });
 }
@@ -302,6 +303,10 @@ document.addEventListener("keydown", (event) => {
 function ensureOverlay() {
   if (overlayFrame && overlayCard && overlayFrame.parentNode) {
     return overlayCard;
+  }
+
+  if (!document.body) {
+    return null;
   }
 
   // Enable Trusted Types if they are available in the current browser.
@@ -570,7 +575,7 @@ function renderProblems() {
     marginTop: "4px",
     paddingTop: "16px",
     borderTop: "1px solid #465e69",
-    color: "#999999",
+    color: theme.muted,
     fontSize: "13px",
   });
   hint.textContent = paginated

--- a/client-src/theme.js
+++ b/client-src/theme.js
@@ -1,0 +1,11 @@
+// Shared palette used by the error overlay and the building indicator.
+export default {
+  // Dark panel and its translucent variant.
+  panel: "#101619",
+  panelTranslucent: "rgba(16,22,25,0.92)",
+  // webpack "Outer Space" (#2B3A42), translucent.
+  backdrop: "rgba(43,58,66,0.72)",
+  text: "#f2f2f2",
+  muted: "#999999",
+  accent: "#8dd6f9",
+};

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -12,12 +12,13 @@
   "words": [
     "Consolas",
     "cspellcache",
+    "CSSOM",
     "darkgrey",
     "eslintcache",
     "esmodules",
-    "noopener",
-    "noreferrer",
+    "mbold",
     "mred",
-    "mbold"
+    "noopener",
+    "noreferrer"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
       "default": "./dist/index.js"
     },
     "./client": "./client/index.js",
+    "./client/indicator": "./client/indicator.js",
     "./client/overlay": "./client/overlay.js",
     "./package.json": "./package.json"
   },

--- a/src/hot.js
+++ b/src/hot.js
@@ -15,6 +15,7 @@
  * @property {string=} path the path the SSE endpoint is served at
  * @property {number=} heartbeat heartbeat interval in milliseconds
  * @property {StatsOptions=} statsOptions webpack stats options used when serializing compilation results
+ * @property {boolean=} progress publish compilation progress events to the clients
  */
 
 /**
@@ -24,6 +25,8 @@
  * @property {string=} name name
  * @property {number=} time time
  * @property {string=} hash hash
+ * @property {number=} percent compilation progress (0-100)
+ * @property {string=} message progress message
  * @property {string[]=} warnings warnings
  * @property {string[]=} errors errors
  */
@@ -259,15 +262,39 @@ function createHot(compiler, userOptions) {
 
   let eventStream = createEventStream(heartbeat, logger);
   logger.log(`Hot module replacement enabled, serving events at "${path}"`);
+
   /** @type {Stats | MultiStats | null} */
   let latestStats = null;
   let closed = false;
+  let lastProgressPercent = -1;
+
+  if (options.progress) {
+    const { webpack } =
+      "compilers" in compiler ? compiler.compilers[0] : compiler;
+
+    // Published only when the rounded percent changes to keep the stream small.
+    new webpack.ProgressPlugin((percent, message) => {
+      const rounded = Math.round(percent * 100);
+
+      if (closed || rounded === lastProgressPercent) {
+        return;
+      }
+
+      lastProgressPercent = rounded;
+      eventStream.publish({
+        action: "progress",
+        percent: rounded,
+        message: message || "",
+      });
+    }).apply(compiler);
+  }
 
   /** @param {string | null=} fileName file that triggered the rebuild */
   const onInvalid = (fileName) => {
     if (closed) return;
 
     latestStats = null;
+    lastProgressPercent = -1;
 
     /** @type {{ action: string, file?: string }} */
     const payload = { action: "building" };

--- a/src/options.json
+++ b/src/options.json
@@ -199,6 +199,10 @@
               "type": "number",
               "minimum": 0
             },
+            "progress": {
+              "description": "Publish compilation progress events to the clients.",
+              "type": "boolean"
+            },
             "statsOptions": {
               "description": "Webpack stats options used when serializing compilation results.",
               "anyOf": [

--- a/test/__snapshots__/validation-options.test.js.snap.webpack5
+++ b/test/__snapshots__/validation-options.test.js.snap.webpack5
@@ -90,31 +90,31 @@ exports[`validation should throw an error on the "hot" option with "{"path":""}"
 exports[`validation should throw an error on the "hot" option with "{"unknown":true}" value 1`] = `
 "Invalid options object. Dev Middleware has been initialized using an options object that does not match the API schema.
  - options.hot has an unknown property 'unknown'. These properties are valid:
-   object { path?, heartbeat?, statsOptions? }"
+   object { path?, heartbeat?, progress?, statsOptions? }"
 `;
 
 exports[`validation should throw an error on the "hot" option with "0" value 1`] = `
 "Invalid options object. Dev Middleware has been initialized using an options object that does not match the API schema.
  - options.hot should be one of these:
-   boolean | object { path?, heartbeat?, statsOptions? }
+   boolean | object { path?, heartbeat?, progress?, statsOptions? }
    -> Enable hot module replacement via a Server-Sent Events endpoint.
    -> Read more at https://github.com/webpack/webpack-dev-middleware#hot
    Details:
     * options.hot should be a boolean.
     * options.hot should be an object:
-      object { path?, heartbeat?, statsOptions? }"
+      object { path?, heartbeat?, progress?, statsOptions? }"
 `;
 
 exports[`validation should throw an error on the "hot" option with "foo" value 1`] = `
 "Invalid options object. Dev Middleware has been initialized using an options object that does not match the API schema.
  - options.hot should be one of these:
-   boolean | object { path?, heartbeat?, statsOptions? }
+   boolean | object { path?, heartbeat?, progress?, statsOptions? }
    -> Enable hot module replacement via a Server-Sent Events endpoint.
    -> Read more at https://github.com/webpack/webpack-dev-middleware#hot
    Details:
     * options.hot should be a boolean.
     * options.hot should be an object:
-      object { path?, heartbeat?, statsOptions? }"
+      object { path?, heartbeat?, progress?, statsOptions? }"
 `;
 
 exports[`validation should throw an error on the "index" option with "{}" value 1`] = `

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -84,6 +84,11 @@ function loadClient(resourceQuery = "") {
 
 describe("client", () => {
   afterEach(() => {
+    for (const el of document.querySelectorAll(
+      "#webpack-dev-middleware-building-indicator",
+    )) {
+      el.remove();
+    }
     delete globalThis.__resourceQuery;
     delete globalThis.EventSource;
     delete globalThis.__wdmEventSourceWrapper;
@@ -737,6 +742,79 @@ describe("client", () => {
       expect(EventSourceStub.lastInstance().url).toBe(
         "https://localhost:3000/assets/__webpack_hmr",
       );
+    });
+  });
+
+  describe("with progress option", () => {
+    const INDICATOR_ID = "webpack-dev-middleware-building-indicator";
+    let EventSourceStub;
+
+    beforeEach(() => {
+      EventSourceStub = makeEventSourceStub();
+      globalThis.EventSource = EventSourceStub;
+      jest.spyOn(console, "info").mockImplementation(() => {});
+      jest.spyOn(console, "log").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it("shows the badge while building and hides it when built", () => {
+      loadClient();
+      const es = EventSourceStub.lastInstance();
+
+      es.onmessage(makeMessage({ action: "building", file: "/src/a.js" }));
+
+      const host = document.getElementById(INDICATOR_ID);
+
+      expect(host).not.toBeNull();
+      expect(host.shadowRoot.textContent).toContain("Rebuilding");
+      expect(host.shadowRoot.textContent).toContain("/src/a.js");
+
+      es.onmessage(
+        makeMessage({
+          action: "built",
+          time: 1,
+          hash: "h",
+          errors: [],
+          warnings: [],
+        }),
+      );
+
+      expect(document.getElementById(INDICATOR_ID)).toBeNull();
+    });
+
+    it("updates the badge with progress events", () => {
+      loadClient();
+      const es = EventSourceStub.lastInstance();
+
+      es.onmessage(makeMessage({ action: "building" }));
+      es.onmessage(
+        makeMessage({ action: "progress", percent: 42, message: "building" }),
+      );
+
+      const host = document.getElementById(INDICATOR_ID);
+
+      expect(host.shadowRoot.textContent).toContain("42%");
+
+      // The progress ring replaces the pulsing dot and reflects the percent.
+      const [, ringValue] = host.shadowRoot.querySelectorAll("circle");
+      const length = 2 * Math.PI * 6;
+
+      expect(Number(ringValue.getAttribute("stroke-dashoffset"))).toBeCloseTo(
+        length * (1 - 42 / 100),
+        3,
+      );
+    });
+
+    it("does not show the badge when progress is disabled", () => {
+      loadClient("?progress=false");
+      EventSourceStub.lastInstance().onmessage(
+        makeMessage({ action: "building" }),
+      );
+
+      expect(document.getElementById(INDICATOR_ID)).toBeNull();
     });
   });
 

--- a/test/hot.test.js
+++ b/test/hot.test.js
@@ -419,6 +419,103 @@ describe("createHot", () => {
     hot.close();
   });
 
+  it("publishes throttled progress events when progress is enabled", () => {
+    const compiler = makeFakeCompiler();
+    /** @type {EXPECTED_OBJECT} */
+    let progressHandler;
+
+    compiler.webpack = {
+      ProgressPlugin: class {
+        /** @param {EXPECTED_OBJECT} handler handler */
+        constructor(handler) {
+          progressHandler = handler;
+        }
+
+        apply() {}
+      },
+    };
+
+    const hot = createHot(compiler, { progress: true });
+    const { writes } = attachClient({ handler: hot.handle });
+
+    progressHandler(0.1, "building");
+    // Same rounded percent — must be skipped.
+    progressHandler(0.101, "building");
+    progressHandler(0.5, "sealing");
+
+    const progressWrites = writes.filter((w) =>
+      w.includes('"action":"progress"'),
+    );
+
+    expect(progressWrites).toHaveLength(2);
+    expect(progressWrites.some((w) => w.includes('"percent":10'))).toBe(true);
+    expect(
+      progressWrites.some(
+        (w) => w.includes('"percent":50') && w.includes('"message":"sealing"'),
+      ),
+    ).toBe(true);
+
+    hot.close();
+  });
+
+  it("resets the progress throttle when a new build starts", () => {
+    const compiler = makeFakeCompiler();
+    /** @type {EXPECTED_OBJECT} */
+    let progressHandler;
+
+    compiler.webpack = {
+      ProgressPlugin: class {
+        /** @param {EXPECTED_OBJECT} handler handler */
+        constructor(handler) {
+          progressHandler = handler;
+        }
+
+        apply() {}
+      },
+    };
+
+    const hot = createHot(compiler, { progress: true });
+    const { writes } = attachClient({ handler: hot.handle });
+
+    progressHandler(1, "done");
+    writes.length = 0;
+
+    // A new build whose first report rounds to the same percent must still
+    // be published.
+    compiler.emitInvalid();
+    progressHandler(1, "done");
+
+    expect(writes.some((w) => w.includes('"action":"progress"'))).toBe(true);
+
+    hot.close();
+  });
+
+  it("does not publish progress events after close()", () => {
+    const compiler = makeFakeCompiler();
+    /** @type {EXPECTED_OBJECT} */
+    let progressHandler;
+
+    compiler.webpack = {
+      ProgressPlugin: class {
+        /** @param {EXPECTED_OBJECT} handler handler */
+        constructor(handler) {
+          progressHandler = handler;
+        }
+
+        apply() {}
+      },
+    };
+
+    const hot = createHot(compiler, { progress: true });
+    const { writes } = attachClient({ handler: hot.handle });
+
+    hot.close();
+    writes.length = 0;
+    progressHandler(0.5, "sealing");
+
+    expect(writes).toHaveLength(0);
+  });
+
   it("stops publishing after close() even if the compiler still emits", () => {
     const compiler = makeFakeCompiler();
     const hot = createHot(compiler, {});

--- a/types/hot.d.ts
+++ b/types/hot.d.ts
@@ -56,6 +56,7 @@ declare const HOT_DEFAULT_HEARTBEAT: number;
  * @property {string=} path the path the SSE endpoint is served at
  * @property {number=} heartbeat heartbeat interval in milliseconds
  * @property {StatsOptions=} statsOptions webpack stats options used when serializing compilation results
+ * @property {boolean=} progress publish compilation progress events to the clients
  */
 /**
  * @typedef {object} Payload
@@ -64,6 +65,8 @@ declare const HOT_DEFAULT_HEARTBEAT: number;
  * @property {string=} name name
  * @property {number=} time time
  * @property {string=} hash hash
+ * @property {number=} percent compilation progress (0-100)
+ * @property {string=} message progress message
  * @property {string[]=} warnings warnings
  * @property {string[]=} errors errors
  */
@@ -153,6 +156,10 @@ type HotOptions = {
    * webpack stats options used when serializing compilation results
    */
   statsOptions?: StatsOptions | undefined;
+  /**
+   * publish compilation progress events to the clients
+   */
+  progress?: boolean | undefined;
 };
 type Payload = {
   /**
@@ -175,6 +182,14 @@ type Payload = {
    * hash
    */
   hash?: string | undefined;
+  /**
+   * compilation progress (0-100)
+   */
+  percent?: number | undefined;
+  /**
+   * progress message
+   */
+  message?: string | undefined;
   /**
    * warnings
    */


### PR DESCRIPTION
The client shows a small badge (shadow DOM, CSSOM-only styles) while a rebuild is in progress, enabled by default (disable with `?progress=false` on the client entry). When the server enables the new `hot.progress` option, webpack's ProgressPlugin publishes throttled `progress` events over SSE (deduplicated by rounded percent, reset on each new build) and the badge renders a CSP-safe SVG progress ring with the compilation percentage.

The palette is shared with the error overlay through a common theme module, and the indicator is exposed as a standalone subpath export (webpack-dev-middleware/client/indicator) so other tooling can reuse it. Both the indicator and the overlay now bail out safely when `document.body` does not exist yet.

Ref webpack/webpack-hot-middleware#167

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->