### PR TITLE
feat(client): collapse the updated-modules list in the console

### DIFF
--- a/client-src/process-update.js
+++ b/client-src/process-update.js
@@ -108,10 +108,13 @@ export default function applyUpdate(hash, options) {
     if (!renewedModules || renewedModules.length === 0) {
       log.info("Nothing hot updated.");
     } else {
-      log.info("Updated modules:");
+      log.info(`Hot updated ${renewedModules.length} modules.`);
+      // Detail as a collapsed group, visible from the "log" level up.
+      log.groupCollapsed("Updated modules:");
       for (const moduleId of renewedModules) {
-        log.info(` - ${moduleId}`);
+        log.log(` - ${moduleId}`);
       }
+      log.groupEnd();
     }
 
     if (upToDate()) {

--- a/test/process-update.test.js
+++ b/test/process-update.test.js
@@ -189,7 +189,18 @@ describe("process-update", () => {
       return spy.mock.calls.some((call) => call.join(" ").includes(text));
     }
 
-    it("lists the updated modules at the default info level", async () => {
+    beforeEach(() => {
+      if (typeof console.groupCollapsed !== "function") {
+        console.groupCollapsed = () => {};
+      }
+      if (typeof console.groupEnd !== "function") {
+        console.groupEnd = () => {};
+      }
+      jest.spyOn(console, "groupCollapsed").mockImplementation(() => {});
+      jest.spyOn(console, "groupEnd").mockImplementation(() => {});
+    });
+
+    it("logs a one-line summary at the default info level", async () => {
       applyUpdate = loadApplyUpdate(
         makeFakeHot({
           checkResult: ["./a.js", "./b.js"],
@@ -201,9 +212,35 @@ describe("process-update", () => {
       globalThis.__webpack_hash__ = "new-hash";
       await flushPromises();
 
-      expect(logged(console.info, "Updated modules:")).toBe(true);
-      expect(logged(console.info, "./a.js")).toBe(true);
-      expect(logged(console.info, "./b.js")).toBe(true);
+      expect(logged(console.info, "Hot updated 2 modules.")).toBe(true);
+      // Groups are gated below the "log" level.
+      expect(console.groupCollapsed).not.toHaveBeenCalled();
+      expect(logged(console.log, "./a.js")).toBe(false);
+    });
+
+    it("adds a collapsed group with the module detail at the log level", async () => {
+      applyUpdate = loadApplyUpdate(
+        makeFakeHot({
+          checkResult: ["./a.js", "./b.js"],
+          applyImpl: () => Promise.resolve(["./a.js", "./b.js"]),
+        }),
+      );
+      setLogLevel("log");
+
+      applyUpdate("new-hash", { reload: true });
+      globalThis.__webpack_hash__ = "new-hash";
+      await flushPromises();
+
+      expect(logged(console.info, "Hot updated 2 modules.")).toBe(true);
+      expect(
+        logged(
+          /** @type {jest.Mock} */ (console.groupCollapsed),
+          "Updated modules:",
+        ),
+      ).toBe(true);
+      expect(logged(console.log, "./a.js")).toBe(true);
+      expect(logged(console.log, "./b.js")).toBe(true);
+      expect(console.groupEnd).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
The success path now logs a one-line summary with the module count at the default "info" level, and the per-module detail as a collapsed console group visible from the "log" level up (webpack's runtime logger gates groups below that level). The unaccepted-modules warning list stays flat: it is diagnostic output for the failing case.

Ref webpack/webpack-hot-middleware#311

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->