### PR TITLE
feat(client): share the overlay across bundled copies and report by source

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,19 @@ overlay.showProblems("errors", ["Something broke"]);
 overlay.clear();
 ```
 
+The overlay state is a per-page singleton: every bundled copy of the module
+renders into the same overlay. Multiple clients can report side by side by
+passing a `source` — each source keeps its own slot and the overlay shows the
+union, with errors from any source taking precedence over warnings:
+
+```js
+overlay.showProblems("errors", ["Something broke"], "my-client");
+// Drop only this client's problems; other sources stay on screen.
+overlay.clear("my-client");
+// Without a source, everything is dismissed (same as Esc / backdrop / ×).
+overlay.clear();
+```
+
 The building indicator is exposed the same way:
 
 ```js

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -356,7 +356,10 @@ function createReporter() {
       return false;
     }
 
-    overlay.clear();
+    // Clear only this client's problems and the runtime errors — other
+    // clients sharing the overlay keep theirs.
+    overlay.clear("");
+    overlay.clear("runtime");
     return true;
   };
 

--- a/client-src/overlay.js
+++ b/client-src/overlay.js
@@ -121,26 +121,68 @@ const colors = {
   darkgrey: "6d7891",
 };
 
-/** @type {HTMLIFrameElement | null} */
-let overlayFrame = null;
-/** @type {HTMLElement | null} */
-let overlayCard = null;
+/**
+ * @typedef {object} OverlayState
+ * @property {HTMLIFrameElement | null} frame overlay iframe
+ * @property {HTMLElement | null} card visible panel inside the iframe
+ * @property {boolean} runtimeListenersAttached whether the window listeners are attached
+ * @property {number} pageIndex page shown when paginating
+ * @property {Record<string, { type: "errors" | "warnings", lines: string[] }>} problemsBySource each reporting source's problems
+ * @property {{ type: "errors" | "warnings", lines: string[] } | null} currentProblems union of every source, as displayed
+ * @property {{ createHTML: (value: string) => EXPECTED_ANY } | undefined} trustedTypesPolicy trusted types policy
+ * @property {boolean | ((error: Error) => boolean)} catchRuntimeError whether (or which) runtime errors are shown — shared, so the copy that attached the window listeners honors every copy's configuration
+ */
 
-// Runtime error capture (same behavior as webpack-dev-server's
-// `catchRuntimeError`): uncaught errors and unhandled promise rejections are
-// rendered in the overlay. Messages accumulate until the overlay is cleared.
-/** @type {string[]} */
-let runtimeMessages = [];
-let runtimeListenersAttached = false;
-/** @type {boolean | ((error: Error) => boolean)} */
-let catchRuntimeError = false;
+/** @returns {OverlayState} fresh overlay state */
+function createOverlayState() {
+  return {
+    frame: null,
+    card: null,
+    runtimeListenersAttached: false,
+    pageIndex: 0,
+    problemsBySource: {},
+    currentProblems: null,
+    trustedTypesPolicy: undefined,
+    catchRuntimeError: false,
+  };
+}
+
+// The DOM/problem state is a per-page singleton shared through `window`, so
+// every bundled copy of this module (e.g. the webpack-dev-server client and
+// the webpack-dev-middleware client on the same page) renders into a single
+// overlay instead of stacking duplicate iframes.
+const OVERLAY_STATE_KEY = "__webpack_dev_middleware_hot_overlay_state__";
+
+/** @type {OverlayState} */
+const state = (() => {
+  if (typeof window === "undefined") {
+    return createOverlayState();
+  }
+
+  const holder = /** @type {EXPECTED_ANY} */ (window);
+
+  if (!holder[OVERLAY_STATE_KEY]) {
+    holder[OVERLAY_STATE_KEY] = createOverlayState();
+  } else {
+    // A copy from another package version may have created the state with
+    // fewer fields — fill the gaps in place (replacing the object would
+    // orphan the references other copies already hold).
+    const defaults = createOverlayState();
+
+    for (const key of Object.keys(defaults)) {
+      if (!(key in holder[OVERLAY_STATE_KEY])) {
+        holder[OVERLAY_STATE_KEY][key] =
+          defaults[/** @type {keyof OverlayState} */ (key)];
+      }
+    }
+  }
+
+  return holder[OVERLAY_STATE_KEY];
+})();
 
 // Pagination (wdm extension, enabled by default): the card shows one problem
 // at a time with prev/next navigation.
 let paginate = true;
-let pageIndex = 0;
-/** @type {{ type: "errors" | "warnings", lines: string[] } | null} */
-let currentProblems = null;
 
 // When set, the file chips in error messages become clickable and issue
 // `GET <endpoint>?fileName=<file:line:column>`. The endpoint itself is
@@ -151,9 +193,8 @@ let openEditorEndpoint = "";
 
 // Trusted Types support (same pattern as webpack-dev-server): when the page
 // runs under `require-trusted-types-for 'script'`, every `innerHTML` write
-// must go through a policy.
-/** @type {{ createHTML: (value: string) => EXPECTED_ANY } | undefined} */
-let trustedTypesPolicy;
+// must go through a policy. The policy itself lives in the shared state —
+// creating two policies with the same name throws under an enforced CSP.
 /** @type {string | undefined} */
 let trustedTypesPolicyName;
 
@@ -162,8 +203,8 @@ let trustedTypesPolicyName;
  * @param {string} html html to assign
  */
 function setHTML(element, html) {
-  element.innerHTML = trustedTypesPolicy
-    ? trustedTypesPolicy.createHTML(html)
+  element.innerHTML = state.trustedTypesPolicy
+    ? state.trustedTypesPolicy.createHTML(html)
     : html;
 }
 
@@ -301,8 +342,8 @@ document.addEventListener("keydown", (event) => {
  * document is not available
  */
 function ensureOverlay() {
-  if (overlayFrame && overlayCard && overlayFrame.parentNode) {
-    return overlayCard;
+  if (state.frame && state.card && state.frame.parentNode) {
+    return state.card;
   }
 
   if (!document.body) {
@@ -310,8 +351,8 @@ function ensureOverlay() {
   }
 
   // Enable Trusted Types if they are available in the current browser.
-  if (window.trustedTypes && !trustedTypesPolicy) {
-    trustedTypesPolicy = window.trustedTypes.createPolicy(
+  if (window.trustedTypes && !state.trustedTypesPolicy) {
+    state.trustedTypesPolicy = window.trustedTypes.createPolicy(
       trustedTypesPolicyName || "webpack-dev-middleware#overlay",
       {
         createHTML: (value) => value,
@@ -319,18 +360,18 @@ function ensureOverlay() {
     );
   }
 
-  overlayFrame = document.createElement("iframe");
-  overlayFrame.id = OVERLAY_ID;
-  overlayFrame.src = "about:blank";
-  applyStyle(overlayFrame, backdropStyles);
-  document.body.append(overlayFrame);
+  state.frame = document.createElement("iframe");
+  state.frame.id = OVERLAY_ID;
+  state.frame.src = "about:blank";
+  applyStyle(state.frame, backdropStyles);
+  document.body.append(state.frame);
 
   // A same-origin `about:blank` document is available synchronously.
-  const frameDocument = overlayFrame.contentDocument;
+  const frameDocument = state.frame.contentDocument;
 
   if (!frameDocument || !frameDocument.body) {
-    overlayFrame.remove();
-    overlayFrame = null;
+    state.frame.remove();
+    state.frame = null;
 
     return null;
   }
@@ -343,9 +384,9 @@ function ensureOverlay() {
     if (event.key === "Escape") {
       clear();
     } else if (paginate && event.key === "ArrowLeft") {
-      goToPage(pageIndex - 1);
+      goToPage(state.pageIndex - 1);
     } else if (paginate && event.key === "ArrowRight") {
-      goToPage(pageIndex + 1);
+      goToPage(state.pageIndex + 1);
     }
   });
 
@@ -359,7 +400,7 @@ function ensureOverlay() {
       return;
     }
 
-    if (overlayCard && !overlayCard.contains(target)) {
+    if (state.card && !state.card.contains(target)) {
       clear();
     }
   });
@@ -382,36 +423,76 @@ function ensureOverlay() {
   });
 
   // The card is the visible panel that holds the problem messages.
-  overlayCard = frameDocument.createElement("div");
-  overlayCard.id = CARD_ID;
-  applyStyle(overlayCard, styles);
-  frameDocument.body.append(overlayCard);
+  state.card = frameDocument.createElement("div");
+  state.card.id = CARD_ID;
+  applyStyle(state.card, styles);
+  frameDocument.body.append(state.card);
 
-  return overlayCard;
+  return state.card;
+}
+
+/**
+ * Compute the union of every source's problems. Errors from any source take
+ * precedence over warnings, mirroring the reporter's per-bundle behavior.
+ * @returns {{ type: "errors" | "warnings", lines: string[] } | null} union
+ */
+function computeProblemsUnion() {
+  const slots = Object.values(state.problemsBySource);
+
+  if (slots.length === 0) {
+    return null;
+  }
+
+  const errorLines = slots
+    .filter((slot) => slot.type === "errors")
+    .flatMap((slot) => slot.lines);
+
+  if (errorLines.length > 0) {
+    return { type: "errors", lines: errorLines };
+  }
+
+  return {
+    type: "warnings",
+    lines: slots.flatMap((slot) => slot.lines),
+  };
 }
 
 /**
  * @param {"errors" | "warnings"} type problem type
  * @param {string[]} lines messages to render
+ * @param {string=} source who reports them — each source (e.g. this client,
+ * the webpack-dev-server client, the runtime error capture) keeps its own
+ * slot and the overlay renders the union of every slot
  */
-export function showProblems(type, lines) {
+export function showProblems(type, lines, source = "") {
+  state.problemsBySource[source] = { type, lines: [...lines] };
+
+  const union =
+    /** @type {{ type: "errors" | "warnings", lines: string[] }} */
+    (computeProblemsUnion());
+
   // Re-publishing an identical set (e.g. another bundle of a multi-compiler
   // synced) must not reset the page the user is reading.
   const unchanged =
-    currentProblems !== null &&
-    overlayFrame !== null &&
-    currentProblems.type === type &&
-    currentProblems.lines.length === lines.length &&
-    currentProblems.lines.every((line, index) => line === lines[index]);
+    state.currentProblems !== null &&
+    state.frame !== null &&
+    // The frame may have been detached without `clear()` (e.g. a framework
+    // wiping `document.body`) — an identical set must still re-mount it.
+    state.frame.parentNode !== null &&
+    state.currentProblems.type === union.type &&
+    state.currentProblems.lines.length === union.lines.length &&
+    state.currentProblems.lines.every(
+      (line, index) => line === union.lines[index],
+    );
 
-  currentProblems = { type, lines };
+  state.currentProblems = union;
 
   if (unchanged) {
     return;
   }
 
   // Each new problem set starts at its first page.
-  pageIndex = 0;
+  state.pageIndex = 0;
   renderProblems();
 }
 
@@ -420,11 +501,14 @@ export function showProblems(type, lines) {
  * @param {number} index requested page index
  */
 function goToPage(index) {
-  if (!currentProblems) {
+  if (!state.currentProblems) {
     return;
   }
 
-  pageIndex = Math.min(currentProblems.lines.length - 1, Math.max(0, index));
+  state.pageIndex = Math.min(
+    state.currentProblems.lines.length - 1,
+    Math.max(0, index),
+  );
   renderProblems();
 }
 
@@ -432,7 +516,7 @@ function goToPage(index) {
  * Render the current problem set into the card.
  */
 function renderProblems() {
-  if (!currentProblems) {
+  if (!state.currentProblems) {
     return;
   }
 
@@ -443,9 +527,9 @@ function renderProblems() {
   }
 
   const frameDocument = /** @type {Document} */ (
-    /** @type {HTMLIFrameElement} */ (overlayFrame).contentDocument
+    /** @type {HTMLIFrameElement} */ (state.frame).contentDocument
   );
-  const { type, lines } = currentProblems;
+  const { type, lines } = state.currentProblems;
   const paginated = paginate && lines.length > 1;
 
   // Accent the top bar with the problem color (red for errors, yellow for warnings).
@@ -463,7 +547,7 @@ function renderProblems() {
   });
   card.append(closeButton);
 
-  const visible = paginated ? [lines[pageIndex]] : lines;
+  const visible = paginated ? [lines[state.pageIndex]] : lines;
 
   if (paginated) {
     // Header row: badge and the problem's first line (usually the file
@@ -528,13 +612,13 @@ function renderProblems() {
         padding: "0",
       });
       button.addEventListener("click", () => {
-        goToPage(pageIndex + delta);
+        goToPage(state.pageIndex + delta);
       });
       return button;
     };
 
     const counter = frameDocument.createElement("span");
-    counter.textContent = `${pageIndex + 1} / ${lines.length}`;
+    counter.textContent = `${state.pageIndex + 1} / ${lines.length}`;
     applyStyle(counter, { color: "#f2f2f2" });
 
     nav.append(
@@ -585,18 +669,36 @@ function renderProblems() {
 }
 
 /**
- * Remove the overlay iframe from the DOM.
+ * Remove one source's problems, or the whole overlay.
+ * @param {string=} source when given, only that source's problems are
+ * dropped and the overlay re-renders the remaining union; without it the
+ * overlay is dismissed entirely (Escape, backdrop, close button)
  */
-export function clear() {
-  if (overlayFrame && overlayFrame.parentNode) {
-    overlayFrame.remove();
+export function clear(source) {
+  if (source !== undefined) {
+    delete state.problemsBySource[source];
+
+    const union = computeProblemsUnion();
+
+    state.currentProblems = union;
+
+    if (union) {
+      state.pageIndex = Math.min(state.pageIndex, union.lines.length - 1);
+      renderProblems();
+
+      return;
+    }
   }
 
-  overlayFrame = null;
-  overlayCard = null;
-  runtimeMessages = [];
-  currentProblems = null;
-  pageIndex = 0;
+  if (state.frame && state.frame.parentNode) {
+    state.frame.remove();
+  }
+
+  state.frame = null;
+  state.card = null;
+  state.problemsBySource = {};
+  state.currentProblems = null;
+  state.pageIndex = 0;
 }
 
 /**
@@ -619,8 +721,8 @@ function handleRuntimeError(error, fallbackMessage) {
 
   // `catchRuntimeError` may be a filter function, like in webpack-dev-server.
   const shouldDisplay =
-    typeof catchRuntimeError === "function"
-      ? catchRuntimeError(errorObject)
+    typeof state.catchRuntimeError === "function"
+      ? state.catchRuntimeError(errorObject)
       : true;
 
   if (!shouldDisplay) {
@@ -628,24 +730,30 @@ function handleRuntimeError(error, fallbackMessage) {
   }
 
   const stack = errorObject.stack ? `\n${errorObject.stack}` : "";
+  const message = `Uncaught runtime error: ${errorObject.message}${stack}`;
 
-  runtimeMessages.push(
-    `Uncaught runtime error: ${errorObject.message}${stack}`,
-  );
-  showProblems("errors", runtimeMessages);
+  // Runtime errors accumulate in their own slot, so they coexist with build
+  // problems and clearing the slot resets the accumulation.
+  const runtimeSlot = state.problemsBySource.runtime;
+  const messages = runtimeSlot ? [...runtimeSlot.lines, message] : [message];
+
+  showProblems("errors", messages, "runtime");
+
   // When paginating, land on the newest runtime error.
-  goToPage(runtimeMessages.length - 1);
+  if (state.currentProblems) {
+    goToPage(state.currentProblems.lines.lastIndexOf(message));
+  }
 }
 
 /**
  * Listen for uncaught errors and unhandled rejections on the page.
  */
 function attachRuntimeErrorListeners() {
-  if (runtimeListenersAttached) {
+  if (state.runtimeListenersAttached) {
     return;
   }
 
-  runtimeListenersAttached = true;
+  state.runtimeListenersAttached = true;
 
   window.addEventListener("error", (event) => {
     if (!event.error && !event.message) {
@@ -678,10 +786,10 @@ export default function configureOverlay(options) {
   }
 
   if (options.catchRuntimeError !== undefined) {
-    catchRuntimeError = options.catchRuntimeError;
+    state.catchRuntimeError = options.catchRuntimeError;
   }
 
-  if (catchRuntimeError) {
+  if (state.catchRuntimeError) {
     attachRuntimeErrorListeners();
   }
 
@@ -700,8 +808,8 @@ export default function configureOverlay(options) {
     }
   }
 
-  if (overlayCard) {
-    applyStyle(overlayCard, styles);
+  if (state.card) {
+    applyStyle(state.card, styles);
   }
 
   return {

--- a/client-src/overlay.js
+++ b/client-src/overlay.js
@@ -676,6 +676,13 @@ function renderProblems() {
  */
 export function clear(source) {
   if (source !== undefined) {
+    // The reporter clears its slots on every clean build — when the source
+    // never reported anything there is nothing to drop, and re-rendering
+    // would needlessly rebuild the card another client is showing.
+    if (!Object.prototype.hasOwnProperty.call(state.problemsBySource, source)) {
+      return;
+    }
+
     delete state.problemsBySource[source];
 
     const union = computeProblemsUnion();

--- a/examples/hot-shared-overlay/README.md
+++ b/examples/hot-shared-overlay/README.md
@@ -1,0 +1,44 @@
+# Shared overlay example
+
+Two separately compiled bundles on one page — each carrying its **own copy**
+of the overlay module — rendering into a **single shared overlay**. This is
+the integration model for webpack-dev-server adopting
+`webpack-dev-middleware/client/overlay`.
+
+## What it shows
+
+- The overlay state lives in a `window` singleton: a second bundled copy of
+  the module adopts the existing iframe instead of stacking a duplicate.
+- Each client reports through its own `source` slot and the overlay renders
+  the union of every slot (with errors taking precedence over warnings).
+- `clear(source)` drops one client's problems without touching the rest;
+  dismissing the overlay (Esc, backdrop, ×) clears everything.
+
+## Files
+
+| File                | Purpose                                                                     |
+| ------------------- | --------------------------------------------------------------------------- |
+| `server.js`         | Express server mounting one middleware instance with `hot: true`.           |
+| `webpack.config.js` | Two compilations: "app" (SSE hot client) and "widget" (standalone overlay). |
+| `src/app.js`        | App entry that accepts updates via `module.hot`.                            |
+| `src/render.js`     | Break this file to produce build errors from the "app" client.              |
+| `src/widget.js`     | Second client: reports its own problems through the `source` slot.          |
+| `public/index.html` | Demo page loading both bundles.                                             |
+
+## Running
+
+From the repository root, build the package first so `dist/` and `client/`
+exist (the example imports `webpack-dev-middleware` by name):
+
+```bash
+npm run build
+node examples/hot-shared-overlay/server.js
+```
+
+Then open <http://localhost:3000> and try:
+
+1. **One overlay, two clients:** click "Report widget error", then break
+   `src/render.js` (e.g. leave a dangling `const x =`) and save — both
+   clients' errors are paginated together in the same overlay.
+2. **Per-source clearing:** click "Widget recovered" — only the widget's
+   problems disappear; the build errors (if any) stay on screen.

--- a/examples/hot-shared-overlay/public/index.html
+++ b/examples/hot-shared-overlay/public/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>webpack-dev-middleware — shared overlay example</title>
+  </head>
+  <body>
+    <main id="root"></main>
+    <section id="widget"></section>
+    <!-- Two separate bundles, each with its own copy of the overlay module. -->
+    <script src="/app.js"></script>
+    <script src="/widget.js"></script>
+  </body>
+</html>

--- a/examples/hot-shared-overlay/server.js
+++ b/examples/hot-shared-overlay/server.js
@@ -1,0 +1,23 @@
+const path = require("path");
+const express = require("express");
+const webpack = require("webpack");
+const middleware = require("webpack-dev-middleware");
+const config = require("./webpack.config.js");
+
+const compiler = webpack(config);
+const app = express();
+
+// One middleware instance serves both compilations and the SSE endpoint.
+app.use(middleware(compiler, { hot: true }));
+
+// Serve the demo page for any non-asset request.
+app.get("/", (req, res) => {
+  res.sendFile(path.join(__dirname, "public", "index.html"));
+});
+
+const port = process.env.PORT || 3000;
+
+app.listen(port, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Example app listening on http://localhost:${port}`);
+});

--- a/examples/hot-shared-overlay/src/app.js
+++ b/examples/hot-shared-overlay/src/app.js
@@ -1,0 +1,11 @@
+import { render } from "./render.js";
+
+render();
+
+// Accept updates to `render.js` and re-run it so the DOM reflects the change
+// without reloading the page.
+if (module.hot) {
+  module.hot.accept("./render.js", () => {
+    render();
+  });
+}

--- a/examples/hot-shared-overlay/src/render.js
+++ b/examples/hot-shared-overlay/src/render.js
@@ -1,0 +1,10 @@
+export function render() {
+  const root = document.getElementById("root");
+
+  // Edit this string (or break the syntax and save) — build problems from
+  // this bundle are reported by the SSE hot client.
+  root.innerHTML = `
+    <p>App bundle: served with hot module replacement over SSE.</p>
+    <p>Break <code>src/render.js</code> and save to see a build error.</p>
+  `;
+}

--- a/examples/hot-shared-overlay/src/widget.js
+++ b/examples/hot-shared-overlay/src/widget.js
@@ -1,0 +1,36 @@
+import configureOverlay from "webpack-dev-middleware/client/overlay";
+
+// This bundle simulates a second client (like webpack-dev-server's once it
+// adopts this overlay): it carries its OWN copy of the overlay module and
+// reports through its own `source` slot. The window singleton makes both
+// copies render into one single overlay — and errors reported by either
+// client take precedence over the other client's warnings.
+const overlay = configureOverlay({});
+
+const SOURCE = "widget";
+
+/** @type {string[]} */
+const errors = [];
+
+const widget = document.getElementById("widget");
+
+widget.innerHTML = `
+  <p>Widget bundle: a separate client with its own copy of the overlay.</p>
+  <button type="button" id="widget-error">Report widget error</button>
+  <button type="button" id="widget-recovered">Widget recovered</button>
+`;
+
+widget.querySelector("#widget-error").addEventListener("click", () => {
+  errors.push(
+    `Widget error #${errors.length + 1}\n` +
+      "Something broke inside the widget bundle.",
+  );
+  overlay.showProblems("errors", errors, SOURCE);
+});
+
+widget.querySelector("#widget-recovered").addEventListener("click", () => {
+  errors.length = 0;
+  // Drops only this client's problems; whatever the other client reported
+  // stays on screen.
+  overlay.clear(SOURCE);
+});

--- a/examples/hot-shared-overlay/webpack.config.js
+++ b/examples/hot-shared-overlay/webpack.config.js
@@ -1,0 +1,46 @@
+const path = require("path");
+const webpack = require("webpack");
+
+// The package `exports` field does not allow query strings on subpaths, so
+// resolve the client entry to a file path first and append the query to that.
+const client = require.resolve("webpack-dev-middleware/client");
+
+/**
+ * Two separate compilations loaded on ONE page. Each bundle carries its own
+ * copy of the overlay module; the window singleton makes both copies render
+ * into a single shared overlay.
+ * @type {import("webpack").Configuration[]}
+ */
+module.exports = [
+  {
+    // The regular hot client: reports build problems over SSE.
+    name: "app",
+    mode: "development",
+    context: __dirname,
+    entry: [`${client}?name=app`, "./src/app.js"],
+    output: {
+      path: path.resolve(__dirname, "dist"),
+      publicPath: "/",
+      filename: "app.js",
+      uniqueName: "app",
+      hotUpdateChunkFilename: "app.[id].[fullhash].hot-update.js",
+      hotUpdateMainFilename: "app.[runtime].[fullhash].hot-update.json",
+    },
+    plugins: [new webpack.HotModuleReplacementPlugin()],
+  },
+  {
+    // Plays the role of a second client (e.g. webpack-dev-server's once it
+    // adopts this overlay): a separate bundle with its OWN copy of the
+    // overlay module, reporting through its own `source` slot.
+    name: "widget",
+    mode: "development",
+    context: __dirname,
+    entry: "./src/widget.js",
+    output: {
+      path: path.resolve(__dirname, "dist"),
+      publicPath: "/",
+      filename: "widget.js",
+      uniqueName: "widget",
+    },
+  },
+];

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -272,7 +272,8 @@ describe("client", () => {
         }),
       );
       expect(clientOverlay.showProblems).toHaveBeenCalledTimes(1);
-      expect(clientOverlay.clear).toHaveBeenCalledTimes(1);
+      expect(clientOverlay.clear).toHaveBeenCalledWith("");
+      expect(clientOverlay.clear).toHaveBeenCalledWith("runtime");
     });
 
     it("updates overlay when an errored build becomes a warning", () => {
@@ -427,7 +428,8 @@ describe("client", () => {
           warnings: [],
         }),
       );
-      expect(clientOverlay.clear).toHaveBeenCalledTimes(1);
+      expect(clientOverlay.clear).toHaveBeenCalledWith("");
+      expect(clientOverlay.clear).toHaveBeenCalledWith("runtime");
     });
 
     it("re-logs the same error text after the bundle's own successful build", () => {
@@ -644,7 +646,8 @@ describe("client", () => {
         }),
       );
       expect(clientOverlay.showProblems).toHaveBeenCalledTimes(1);
-      expect(clientOverlay.clear).toHaveBeenCalledTimes(1);
+      expect(clientOverlay.clear).toHaveBeenCalledWith("");
+      expect(clientOverlay.clear).toHaveBeenCalledWith("runtime");
     });
 
     it("updates overlay after errored build becomes a warning", () => {

--- a/test/overlay.test.js
+++ b/test/overlay.test.js
@@ -522,6 +522,19 @@ describe("overlay", () => {
       expect(getCard().style.borderTopColor).toBe("rgb(255, 211, 14)");
     });
 
+    it("does not re-render when clearing a source that reported nothing", () => {
+      showProblems("errors", ["a", "b"], "x");
+
+      const cardChild = getCard().firstElementChild;
+
+      // What the reporter does on every clean build of its own bundle.
+      clear("never-reported");
+
+      // Same DOM nodes — the card another client is showing was not rebuilt.
+      expect(getCard().firstElementChild).toBe(cardChild);
+      expect(getOverlay()).not.toBeNull();
+    });
+
     it("fills state fields missing from an older copy's shape", () => {
       const OVERLAY_STATE_KEY = "__webpack_dev_middleware_hot_overlay_state__";
 

--- a/test/overlay.test.js
+++ b/test/overlay.test.js
@@ -119,6 +119,17 @@ describe("overlay", () => {
       expect(getCard().textContent).toContain("second");
       expect(getCard().textContent).not.toContain("first");
     });
+
+    it("re-mounts the overlay when the iframe was removed without clear()", () => {
+      showProblems("errors", ["boom"]);
+      // A framework wiping `document.body` removes the iframe behind our back.
+      getOverlay().remove();
+      // Re-publishing the identical set must re-mount, not hit the
+      // unchanged-set guard.
+      showProblems("errors", ["boom"]);
+      expect(getOverlay()).not.toBeNull();
+      expect(getCard().textContent).toContain("boom");
+    });
   });
 
   describe("clear", () => {
@@ -216,6 +227,57 @@ describe("overlay", () => {
       globalThis.dispatchEvent(new ErrorEvent("error", { error }));
 
       expect(getOverlay()).toBeNull();
+    });
+
+    it("resets the accumulation when the runtime slot is cleared", () => {
+      configureOverlay({ catchRuntimeError: true });
+
+      globalThis.dispatchEvent(
+        new ErrorEvent("error", {
+          error: new Error("boom-before"),
+          message: "boom-before",
+        }),
+      );
+      expect(getCard().textContent).toContain("boom-before");
+
+      // What the reporter does on a clean build.
+      clear("runtime");
+      expect(getOverlay()).toBeNull();
+
+      globalThis.dispatchEvent(
+        new ErrorEvent("error", {
+          error: new Error("boom-after"),
+          message: "boom-after",
+        }),
+      );
+
+      expect(getCard().textContent).toContain("boom-after");
+      expect(getCard().textContent).not.toContain("boom-before");
+      expect(getCard().textContent).not.toContain("1 / 2");
+    });
+
+    it("honors the runtime filter configured by a later copy", () => {
+      // The window listeners were attached by this copy…
+      configureOverlay({ catchRuntimeError: true });
+
+      // …but the filter comes from a second bundled copy of the module.
+      jest.resetModules();
+
+      const laterCopy = require("../client-src/overlay");
+
+      laterCopy.default({ catchRuntimeError: () => false });
+
+      globalThis.dispatchEvent(
+        new ErrorEvent("error", {
+          error: new Error("filtered-out"),
+          message: "filtered-out",
+        }),
+      );
+
+      expect(getOverlay()).toBeNull();
+
+      // Restore the plain-boolean configuration for the remaining tests.
+      configureOverlay({ catchRuntimeError: true });
     });
   });
 
@@ -393,6 +455,90 @@ describe("overlay", () => {
 
       // Restore the default so module-level state does not leak.
       configureOverlay({ ansiColors: { red: "ff3348" } });
+    });
+  });
+
+  describe("shared state across module copies", () => {
+    it("shows the errors of two clients in the same overlay", () => {
+      // First client (e.g. the webpack-dev-middleware SSE client) reports.
+      showProblems("errors", ["boom from the wdm client"]);
+
+      expect(document.querySelectorAll("iframe")).toHaveLength(1);
+      expect(getCard().textContent).toContain("boom from the wdm client");
+
+      // A second client bundling its own copy of the module (e.g. the
+      // webpack-dev-server client) reports into the SAME overlay: it adopts
+      // the shared iframe instead of stacking a duplicate, and its own
+      // source slot joins the union next to the first client's problems.
+      jest.resetModules();
+
+      const secondClient = require("../client-src/overlay");
+
+      secondClient.showProblems("errors", ["boom from the wds client"], "wds");
+
+      expect(document.querySelectorAll("iframe")).toHaveLength(1);
+      // Both clients' errors are in the union, paginated together.
+      expect(getCard().textContent).toContain("boom from the wdm client");
+      expect(getCard().textContent).toContain("1 / 2");
+
+      getOverlay().contentDocument.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight" }),
+      );
+      expect(getCard().textContent).toContain("boom from the wds client");
+
+      // The state is shared both ways: dismissing from the first client
+      // removes the overlay the second client rendered.
+      clear();
+      expect(getOverlay()).toBeNull();
+      expect(document.querySelectorAll("iframe")).toHaveLength(0);
+    });
+
+    it("prefers one client's errors over another client's warnings", () => {
+      showProblems("errors", ["boom from the wdm client"]);
+
+      jest.resetModules();
+
+      const secondClient = require("../client-src/overlay");
+
+      // Errors from any source suppress warnings in the union, so another
+      // client's warnings do not hide the broken build.
+      secondClient.showProblems(
+        "warnings",
+        ["careful from the wds client"],
+        "wds",
+      );
+
+      expect(document.querySelectorAll("iframe")).toHaveLength(1);
+      expect(getCard().textContent).toContain("boom from the wdm client");
+      expect(getCard().textContent).not.toContain(
+        "careful from the wds client",
+      );
+      expect(getCard().style.borderTopColor).toBe("rgb(255, 51, 72)");
+
+      // Once the erroring source recovers, the warnings surface.
+      secondClient.clear("");
+
+      expect(getCard().textContent).toContain("careful from the wds client");
+      expect(getCard().style.borderTopColor).toBe("rgb(255, 211, 14)");
+    });
+
+    it("fills state fields missing from an older copy's shape", () => {
+      const OVERLAY_STATE_KEY = "__webpack_dev_middleware_hot_overlay_state__";
+
+      // Simulate an older package version having created a leaner state.
+      window[OVERLAY_STATE_KEY] = { frame: null, card: null };
+
+      jest.resetModules();
+
+      const newerCopy = require("../client-src/overlay");
+
+      expect(() =>
+        newerCopy.showProblems("errors", ["boom"], "newer"),
+      ).not.toThrow();
+      expect(document.querySelectorAll("iframe")).toHaveLength(1);
+
+      newerCopy.clear();
+      delete window[OVERLAY_STATE_KEY];
     });
   });
 });


### PR DESCRIPTION
The overlay DOM and problem state now live in a window singleton, so a second bundled copy of the module (e.g. the webpack-dev-server client once it adopts this overlay) renders into the same iframe instead of stacking a duplicate. Fields missing from a state created by an older copy are filled in place, and the Trusted Types policy moves into the shared state too — creating two policies with the same name throws under an enforced CSP.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->