### PR TITLE
feat: reuse an already active MultiWatching

### DIFF
--- a/.changeset/reuse-active-multiwatching.md
+++ b/.changeset/reuse-active-multiwatching.md
@@ -1,0 +1,5 @@
+---
+"webpack-dev-middleware": minor
+---
+
+Reuse an already active `MultiCompiler` watching session instead of starting a duplicate one (requires webpack >= 5.109).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webpack-dev-middleware",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webpack-dev-middleware",
-      "version": "8.0.3",
+      "version": "8.0.4",
       "license": "MIT",
       "dependencies": {
         "memfs": "^4.56.10",
@@ -50,7 +50,7 @@
         "router": "^2.2.0",
         "supertest": "^7.0.0",
         "typescript": "^6.0.2",
-        "webpack": "^5.101.0"
+        "webpack": "^5.109.0"
       },
       "engines": {
         "node": ">= 20.9.0"
@@ -6087,19 +6087,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-import-phases": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "acorn": "^8.14.0"
-      }
-    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -8219,9 +8206,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.0.tgz",
-      "integrity": "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==",
+      "version": "5.24.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10600,13 +10587,6 @@
       "peerDependencies": {
         "tslib": "2"
       }
-    },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true,
-      "license": "BSD-2-Clause"
     },
     "node_modules/global-directory": {
       "version": "5.0.0",
@@ -13278,20 +13258,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/loader-runner": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
-      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.11.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
     "node_modules/loader-utils": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
@@ -14645,6 +14611,98 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimizer-webpack-plugin": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/minimizer-webpack-plugin/node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/minimizer-webpack-plugin/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/minipass": {
@@ -17425,9 +17483,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
-      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -17441,98 +17499,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/terser-webpack-plugin": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.0.tgz",
-      "integrity": "sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jest-worker": "^27.4.5",
-        "schema-utils": "^4.3.0",
-        "terser": "^5.31.1"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@minify-html/node": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/css": {
-          "optional": true
-        },
-        "@swc/html": {
-          "optional": true
-        },
-        "clean-css": {
-          "optional": true
-        },
-        "cssnano": {
-          "optional": true
-        },
-        "csso": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "html-minifier-terser": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "uglify-js": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/terser/node_modules/commander": {
@@ -18302,13 +18268,12 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       },
       "engines": {
@@ -18323,9 +18288,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.107.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
-      "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
+      "version": "5.109.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.0.tgz",
+      "integrity": "sha512-vomrngskVVXEZF9sMZfYAd4pXZUnfaWdJGlF+BTNF+gJBCKYCQBnOeVPlrh39Ewl7nlCsirDplMy6o5g9xJHBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18335,23 +18300,20 @@
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.16.0",
-        "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.22.0",
+        "enhanced-resolve": "^5.24.2",
         "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "loader-runner": "^4.3.2",
         "mime-db": "^1.54.0",
+        "minimizer-webpack-plugin": "^5.6.1",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.5.0",
-        "watchpack": "^2.5.1",
-        "webpack-sources": "^3.5.0"
+        "watchpack": "^2.5.2",
+        "webpack-sources": "^3.5.1"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -18370,9 +18332,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
-      "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+      "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "router": "^2.2.0",
     "supertest": "^7.0.0",
     "typescript": "^6.0.2",
-    "webpack": "^5.101.0"
+    "webpack": "^5.109.0"
   },
   "peerDependencies": {
     "webpack": "^5.101.0"

--- a/src/index.js
+++ b/src/index.js
@@ -559,16 +559,17 @@ function wdm(compiler, options = {}, isPlugin = false) {
       }
     };
 
-    if (isMultipleCompiler(compiler)) {
-      // TODO improve on webpack side - add an option `watching(s)` for MultiCompiler
+    if (compiler.watching) {
+      // Reuse the active watching session instead of starting a second one
+      // (exposed on `MultiCompiler` since webpack 5.109).
+      context.watching = compiler.watching;
+    } else if (isMultipleCompiler(compiler)) {
       context.watching = compiler.watch(
         compiler.compilers.map(
           (compiler) => compiler.options.watchOptions || {},
         ),
         errorHandler,
       );
-    } else if (compiler.watching) {
-      context.watching = compiler.watching;
     } else {
       context.watching = compiler.watch(
         compiler.options.watchOptions || {},

--- a/test/__snapshots__/logging.test.js.snap.webpack5
+++ b/test/__snapshots__/logging.test.js.snap.webpack5
@@ -19,9 +19,11 @@ asset bundle.js x KiB [emitted] (name: main)
 
 ERROR in ./broken.js 1:3
 Module parse failed: Unexpected token (1:3)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-> 1()2()3()
-|
+> 1 |1()2()3()
+| ^
+2 |
 
 broken (webpack x.x.x) compiled with 1 error in x ms
 
@@ -37,7 +39,7 @@ success:
 asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -53,9 +55,11 @@ exports[`logging plugin should logging in multi-compiler and respect the "stats"
 
 ERROR in ./broken.js 1:3
 Module parse failed: Unexpected token (1:3)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-> 1()2()3()
-|
+> 1 |1()2()3()
+| ^
+2 |
 
 webpack x.x.x compiled with 1 error in x ms
 
@@ -69,7 +73,7 @@ webpack x.x.x compiled with 1 warning in x ms
 asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -85,9 +89,11 @@ exports[`logging plugin should logging in multi-compiler and respect the "stats"
 
 ERROR in ./broken.js 1:3
 Module parse failed: Unexpected token (1:3)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-> 1()2()3()
-|
+> 1 |1()2()3()
+| ^
+2 |
 
 webpack x.x.x compiled with 1 error in x ms
 
@@ -113,7 +119,7 @@ webpack x.x.x compiled successfully in x ms
 asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -129,9 +135,11 @@ exports[`logging plugin should logging in multi-compiler and respect the "stats"
 
 ERROR in ./broken.js 1:3
 Module parse failed: Unexpected token (1:3)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-> 1()2()3()
-|
+> 1 |1()2()3()
+| ^
+2 |
 
 webpack x.x.x compiled with 1 error in x ms
 
@@ -145,7 +153,7 @@ webpack x.x.x compiled with 1 warning in x ms
 asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -256,7 +264,7 @@ webpack/runtime/hasOwnProperty shorthand x bytes {main} [code generated]
 webpack/runtime/make namespace object x bytes {main} [code generated]
 [no exports]
 [used exports unknown]
-webpack/runtime/publicPath x KiB {main} [code generated]
+webpack/runtime/publicPath x bytes {main} [code generated]
 [no exports]
 [used exports unknown]
 cacheable modules x bytes
@@ -282,7 +290,7 @@ exports[`logging plugin should logging on successfully build in multi-compiler m
 "asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -440,7 +448,7 @@ exports[`logging plugin should logging on successfully multi-compiler build usin
 "asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -458,7 +466,7 @@ exports[`logging plugin should logging on successfully multi-compiler build usin
 "asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -476,7 +484,7 @@ exports[`logging plugin should logging on successfully multi-compiler build usin
 "asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -494,7 +502,7 @@ exports[`logging plugin should logging on successfully multi-compiler build usin
 "asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -512,7 +520,7 @@ exports[`logging plugin should logging on successfully multi-compiler build usin
 "asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -530,7 +538,7 @@ exports[`logging plugin should logging on successfully multi-compiler build usin
 "asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -547,17 +555,21 @@ exports[`logging plugin should logging on unsuccessful build in multi-compiler: 
 exports[`logging plugin should logging on unsuccessful build in multi-compiler: stdout 1`] = `
 "ERROR in ./broken.js 1:3
 Module parse failed: Unexpected token (1:3)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-> 1()2()3()
-|
+> 1 |1()2()3()
+| ^
+2 |
 
 webpack compiled with 1 error
 
 ERROR in ./broken.js 1:3
 Module parse failed: Unexpected token (1:3)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-> 1()2()3()
-|
+> 1 |1()2()3()
+| ^
+2 |
 
 webpack compiled with 1 error"
 `;
@@ -567,9 +579,11 @@ exports[`logging plugin should logging on unsuccessful build: stderr 1`] = `""`;
 exports[`logging plugin should logging on unsuccessful build: stdout 1`] = `
 "ERROR in ./broken.js 1:3
 Module parse failed: Unexpected token (1:3)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-> 1()2()3()
-|
+> 1 |1()2()3()
+| ^
+2 |
 
 webpack compiled with 1 error"
 `;
@@ -605,9 +619,11 @@ asset bundle.js x KiB [emitted] (name: main)
 
 ERROR in ./broken.js 1:3
 Module parse failed: Unexpected token (1:3)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-> 1()2()3()
-|
+> 1 |1()2()3()
+| ^
+2 |
 
 broken (webpack x.x.x) compiled with 1 error in x ms
 
@@ -623,7 +639,7 @@ success:
 asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -639,9 +655,11 @@ exports[`logging standalone should logging in multi-compiler and respect the "st
 
 ERROR in ./broken.js 1:3
 Module parse failed: Unexpected token (1:3)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-> 1()2()3()
-|
+> 1 |1()2()3()
+| ^
+2 |
 
 webpack x.x.x compiled with 1 error in x ms
 
@@ -655,7 +673,7 @@ webpack x.x.x compiled with 1 warning in x ms
 asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -671,9 +689,11 @@ exports[`logging standalone should logging in multi-compiler and respect the "st
 
 ERROR in ./broken.js 1:3
 Module parse failed: Unexpected token (1:3)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-> 1()2()3()
-|
+> 1 |1()2()3()
+| ^
+2 |
 
 webpack x.x.x compiled with 1 error in x ms
 
@@ -699,7 +719,7 @@ webpack x.x.x compiled successfully in x ms
 asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -715,9 +735,11 @@ exports[`logging standalone should logging in multi-compiler and respect the "st
 
 ERROR in ./broken.js 1:3
 Module parse failed: Unexpected token (1:3)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-> 1()2()3()
-|
+> 1 |1()2()3()
+| ^
+2 |
 
 webpack x.x.x compiled with 1 error in x ms
 
@@ -731,7 +753,7 @@ webpack x.x.x compiled with 1 warning in x ms
 asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -842,7 +864,7 @@ webpack/runtime/hasOwnProperty shorthand x bytes {main} [code generated]
 webpack/runtime/make namespace object x bytes {main} [code generated]
 [no exports]
 [used exports unknown]
-webpack/runtime/publicPath x KiB {main} [code generated]
+webpack/runtime/publicPath x bytes {main} [code generated]
 [no exports]
 [used exports unknown]
 cacheable modules x bytes
@@ -868,7 +890,7 @@ exports[`logging standalone should logging on successfully build in multi-compil
 "asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -955,7 +977,7 @@ webpack/runtime/hasOwnProperty shorthand x bytes {main} [code generated]
 webpack/runtime/make namespace object x bytes {main} [code generated]
 [no exports]
 [used exports unknown]
-webpack/runtime/publicPath x KiB {main} [code generated]
+webpack/runtime/publicPath x bytes {main} [code generated]
 [no exports]
 [used exports unknown]
 cacheable modules x bytes
@@ -1041,7 +1063,7 @@ exports[`logging standalone should logging on successfully multi-compiler build 
 "asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -1059,7 +1081,7 @@ exports[`logging standalone should logging on successfully multi-compiler build 
 "asset bundle.js x KiB [emitted] (name: main)
 asset svg.svg x KiB [emitted] [from: svg.svg] (auxiliary name: main)
 asset index.html x bytes [emitted] [from: index.html] (auxiliary name: main)
-runtime modules x bytes x modules
+runtime modules x KiB x modules
 cacheable modules x bytes
 ./foo.js x bytes [built] [code generated]
 ./svg.svg x bytes [built] [code generated]
@@ -1086,17 +1108,21 @@ exports[`logging standalone should logging on unsuccessful build in multi-compil
 exports[`logging standalone should logging on unsuccessful build in multi-compiler: stdout 1`] = `
 "ERROR in ./broken.js 1:3
 Module parse failed: Unexpected token (1:3)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-> 1()2()3()
-|
+> 1 |1()2()3()
+| ^
+2 |
 
 webpack compiled with 1 error
 
 ERROR in ./broken.js 1:3
 Module parse failed: Unexpected token (1:3)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-> 1()2()3()
-|
+> 1 |1()2()3()
+| ^
+2 |
 
 webpack compiled with 1 error"
 `;
@@ -1106,9 +1132,11 @@ exports[`logging standalone should logging on unsuccessful build: stderr 1`] = `
 exports[`logging standalone should logging on unsuccessful build: stdout 1`] = `
 "ERROR in ./broken.js 1:3
 Module parse failed: Unexpected token (1:3)
+File was parsed as module type 'javascript/auto'.
 You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-> 1()2()3()
-|
+> 1 |1()2()3()
+| ^
+2 |
 
 webpack compiled with 1 error"
 `;

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -6947,3 +6947,16 @@ describe.each([
     });
   });
 });
+
+describe("watching reuse", () => {
+  it("reuses an already active MultiWatching", (done) => {
+    const compiler = getCompiler(webpackMultiConfig);
+    const watching = compiler.watch({}, () => {});
+    const instance = middleware(compiler);
+
+    expect(instance.context.watching).toBe(watching);
+    expect(compiler.watching).toBe(watching);
+
+    instance.close(done);
+  });
+});

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -313,6 +313,29 @@ function parseHttpDate(date) {
   return typeof timestamp === "number" ? timestamp : Number.NaN;
 }
 
+describe("watching reuse", () => {
+  it("reuses an already active Watching", (done) => {
+    const compiler = getCompiler(webpackConfig);
+    const watching = compiler.watch({}, () => {});
+    const instance = middleware(compiler);
+
+    expect(instance.context.watching).toBe(watching);
+
+    instance.close(done);
+  });
+
+  it("reuses an already active MultiWatching", (done) => {
+    const compiler = getCompiler(webpackMultiConfig);
+    const watching = compiler.watch({}, () => {});
+    const instance = middleware(compiler);
+
+    expect(instance.context.watching).toBe(watching);
+    expect(compiler.watching).toBe(watching);
+
+    instance.close(done);
+  });
+});
+
 describe.each([
   ["connect", connect],
   ["express", express],
@@ -6945,18 +6968,5 @@ describe.each([
         });
       });
     });
-  });
-});
-
-describe("watching reuse", () => {
-  it("reuses an already active MultiWatching", (done) => {
-    const compiler = getCompiler(webpackMultiConfig);
-    const watching = compiler.watch({}, () => {});
-    const instance = middleware(compiler);
-
-    expect(instance.context.watching).toBe(watching);
-    expect(compiler.watching).toBe(watching);
-
-    instance.close(done);
   });
 });


### PR DESCRIPTION
webpack 5.109 exposes the active MultiWatching on MultiCompiler.watching, resolving the old TODO here: when watching was already started (by webpack-cli or the user), the middleware now adopts that session instead of starting a second one — double watchers meant duplicate builds. Older webpack versions fall back to watch() as before.

Also updates the logging snapshots for webpack 5.109's runtime size changes (KiB/bytes boundary shifts in stats output).

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->