### PR TITLE
perf(client): use a Set for renewed module ids in logUpdates

### DIFF
--- a/client-src/process-update.js
+++ b/client-src/process-update.js
@@ -122,8 +122,9 @@ export default function applyUpdate(hash, options, name) {
    * @param {(string | number)[] | null | undefined} renewedModules ids of modules that were successfully renewed
    */
   function logUpdates(updatedModules, renewedModules) {
+    const renewedIds = new Set(renewedModules || []);
     const unacceptedModules = updatedModules.filter(
-      (moduleId) => !renewedModules || !renewedModules.includes(moduleId),
+      (moduleId) => !renewedIds.has(moduleId),
     );
 
     if (unacceptedModules.length > 0) {


### PR DESCRIPTION
Replaces Array#includes inside the filter over updated modules (O(n·m) → O(n+m)) — noticeable on updates touching hundreds of modules.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving micro-optimization in client HMR logging only; no auth, data, or API surface changes.
> 
> **Overview**
> **Hot-module-replacement logging** now builds a `Set` from successfully renewed module ids before filtering which updated modules were not accepted, instead of calling `Array#includes` on every id in the filter.
> 
> That changes `logUpdates` from roughly O(n·m) to O(n+m) when comparing attempted vs renewed modules—mainly helpful when an update touches hundreds of modules, with the same warnings and reload behavior as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 903995f240aeb0849fd92077d1afc31738286c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->