### PR TITLE
perf(hot): avoid idle work on the SSE stream

### DIFF
--- a/src/hot.js
+++ b/src/hot.js
@@ -36,6 +36,7 @@
 /**
  * @typedef {object} EventStream
  * @property {(req: IncomingMessage, res: ServerResponse) => void} handler attach a new client
+ * @property {() => boolean} hasClients true when at least one client is connected
  * @property {(payload: Payload | { action: string }) => void} publish publish a payload to every client
  * @property {(res: ServerResponse, payload: Payload | { action: string }) => void} publishTo publish a payload to a single client
  * @property {() => void} close end every client and stop the heartbeat
@@ -79,26 +80,47 @@ function createEventStream(heartbeat, logger) {
     }
   };
 
-  const interval = setInterval(() => {
-    everyClient((client) => {
-      client.write("data: 💓\n\n");
-    });
-  }, heartbeat);
+  // Runs only while clients are connected: started with the first client,
+  // stopped with the last one.
+  /** @type {ReturnType<typeof setInterval> | null} */
+  let interval = null;
 
-  // Don't block process exit on the heartbeat timer.
-  if (typeof interval.unref === "function") {
-    interval.unref();
-  }
+  const startHeartbeat = () => {
+    if (interval !== null) {
+      return;
+    }
+
+    interval = setInterval(() => {
+      everyClient((client) => {
+        client.write("data: 💓\n\n");
+      });
+    }, heartbeat);
+
+    // Don't block process exit on the heartbeat timer.
+    if (typeof interval.unref === "function") {
+      interval.unref();
+    }
+  };
+
+  const stopHeartbeat = () => {
+    if (interval !== null) {
+      clearInterval(interval);
+      interval = null;
+    }
+  };
 
   return {
     close() {
-      clearInterval(interval);
+      stopHeartbeat();
       everyClient((client) => {
         if (!client.writableEnded) {
           client.end();
         }
       });
       clients = new Map();
+    },
+    hasClients() {
+      return clients.size > 0;
     },
     handler(req, res) {
       // A response another middleware already started can no longer become an
@@ -135,6 +157,7 @@ function createEventStream(heartbeat, logger) {
 
       const id = clientId++;
       clients.set(id, res);
+      startHeartbeat();
       logger.log(`Client connected (${clients.size} active)`);
 
       req.on("close", () => {
@@ -142,10 +165,20 @@ function createEventStream(heartbeat, logger) {
           res.end();
         }
         clients.delete(id);
+
+        if (clients.size === 0) {
+          stopHeartbeat();
+        }
+
         logger.log(`Client disconnected (${clients.size} active)`);
       });
     },
     publish(payload) {
+      // With no clients connected there is nothing to serialize for.
+      if (clients.size === 0) {
+        return;
+      }
+
       const frame = `data: ${JSON.stringify(payload)}\n\n`;
 
       everyClient((client) => {
@@ -261,6 +294,23 @@ function bundlePayload(stats, action) {
  * @param {EventStream} eventStream event stream
  */
 function publishBundles(bundles, previousBundles, eventStream) {
+  // Grouped once up front so pairing stays linear with many child compilers.
+  /** @type {Map<string, StatsCompilation[]>} */
+  const previousByName = new Map();
+
+  if (previousBundles !== null) {
+    for (const bundle of previousBundles) {
+      const name = bundle.name || "";
+      const group = previousByName.get(name);
+
+      if (group) {
+        group.push(bundle);
+      } else {
+        previousByName.set(name, [bundle]);
+      }
+    }
+  }
+
   /** @type {Map<string, number>} */
   const occurrences = new Map();
 
@@ -277,10 +327,8 @@ function publishBundles(bundles, previousBundles, eventStream) {
       if (name) {
         const occurrence = occurrences.get(name) || 0;
         occurrences.set(name, occurrence + 1);
-        previous =
-          previousBundles.filter((bundle) => (bundle.name || "") === name)[
-            occurrence
-          ] || null;
+        const group = previousByName.get(name);
+        previous = (group && group[occurrence]) || null;
       } else {
         previous = previousBundles[index] || null;
       }
@@ -331,9 +379,13 @@ function createHot(compiler, userOptions) {
 
     // Published only when the rounded percent changes to keep the stream small.
     new webpack.ProgressPlugin((percent, message) => {
+      if (closed || !eventStream.hasClients()) {
+        return;
+      }
+
       const rounded = Math.round(percent * 100);
 
-      if (closed || rounded === lastProgressPercent) {
+      if (rounded === lastProgressPercent) {
         return;
       }
 


### PR DESCRIPTION
- skip payload serialization in publish() when no client is connected, and cut the ProgressPlugin callback early via eventStream.hasClients()
- start the heartbeat interval with the first client and stop it with the last one, instead of ticking forever
- pair bundles against the previous build through a name-grouped Map, replacing the per-bundle filter (O(n²) → O(n))

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only changes in dev-middleware HMR; no auth or production build paths, with behavior unchanged when clients are connected.
> 
> **Overview**
> **Reduces CPU and timer work when no browser is connected to the HMR SSE endpoint**, while keeping behavior the same once clients are attached.
> 
> The event stream **starts the heartbeat on the first client and stops it on the last disconnect** (instead of running `setInterval` continuously), exposes **`hasClients()`**, and **`publish()` returns early** without `JSON.stringify` when `clients.size === 0`. With **`progress` enabled**, the `ProgressPlugin` callback **bails out when there are no clients** before publishing percent updates.
> 
> **`publishBundles`** now **indexes previous bundles by name once** and pairs by occurrence from that map, replacing a per-bundle `filter` over the full previous list (**O(n²) → O(n)** for many child compilers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d375f20143da5358e49853dfd1999a1af04199c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->