### PR TITLE
fix(plugin): resolve crash on invalidate() in plugin mode

### DIFF
--- a/.changeset/plugin-mode-invalidate.md
+++ b/.changeset/plugin-mode-invalidate.md
@@ -1,0 +1,5 @@
+---
+"webpack-dev-middleware": patch
+---
+
+Fixed a crash when calling `invalidate()` in plugin mode (`isPlugin = true`). Since the host (webpack-cli, webpack-dev-server, etc.) owns `compiler.watch()`, the middleware now invalidates the host's `watching` instead (each child compiler's one for a `MultiCompiler` on webpack < 5.109), and logs a warning when the compiler is not watching at all.

--- a/.changeset/plugin-mode-invalidate.md
+++ b/.changeset/plugin-mode-invalidate.md
@@ -2,4 +2,4 @@
 "webpack-dev-middleware": patch
 ---
 
-Fixed a crash when calling `invalidate()` in plugin mode (`isPlugin = true`). Since the host (webpack-cli, webpack-dev-server, etc.) owns `compiler.watch()`, the middleware now invalidates the host's `watching` instead (each child compiler's one for a `MultiCompiler` on webpack < 5.109), and logs a warning when the compiler is not watching at all.
+Fixed a crash when calling `invalidate()` in plugin mode (`isPlugin = true`). Since the host (webpack-cli, webpack-dev-server, etc.) owns `compiler.watch()`, the middleware now invalidates the host's `watching` instead (each child compiler's one for a `MultiCompiler` on webpack < 5.109). When nothing is watching it logs a warning and completes the callback, as `close()` does, rather than leaving `invalidate(callback)` waiting on a build that never runs.

--- a/src/index.js
+++ b/src/index.js
@@ -615,9 +615,36 @@ function wdm(compiler, options = {}, isPlugin = false) {
   instance.invalidate = (callback = noop) => {
     middleware.ready(filledContext, callback);
 
-    // TODO for plugin usage (`isPlugin = true`) `watching` is `undefined` and this throws —
-    // invalidate the host's `compiler.watching` (each child's one for a `MultiCompiler`) instead
-    filledContext.watching.invalidate();
+    if (filledContext.watching) {
+      filledContext.watching.invalidate();
+      return;
+    }
+
+    // For plugin usage the host (webpack-cli, webpack-dev-server, etc.) owns
+    // `compiler.watch()`, so invalidate the host's `watching` instead
+    const { compiler: contextCompiler } = filledContext;
+
+    let invalidated = false;
+
+    if (contextCompiler.watching) {
+      contextCompiler.watching.invalidate();
+      invalidated = true;
+    } else if (isMultipleCompiler(contextCompiler)) {
+      // `MultiCompiler` exposes `watching` only since webpack 5.109, fall back
+      // to each child compiler's own `watching`
+      for (const childCompiler of contextCompiler.compilers) {
+        if (childCompiler.watching) {
+          childCompiler.watching.invalidate();
+          invalidated = true;
+        }
+      }
+    }
+
+    if (!invalidated) {
+      filledContext.logger.warn(
+        "The `invalidate` method was called, but the compiler is not watching, so there is nothing to invalidate.",
+      );
+    }
   };
 
   instance.close = (callback = noop) => {

--- a/src/index.js
+++ b/src/index.js
@@ -613,37 +613,43 @@ function wdm(compiler, options = {}, isPlugin = false) {
   };
 
   instance.invalidate = (callback = noop) => {
-    middleware.ready(filledContext, callback);
+    const { compiler: contextCompiler, watching } = filledContext;
+    // Collected before anything is invalidated: with nothing to invalidate,
+    // no build follows, and `ready` would queue the callback against one that
+    // never comes.
+    /** @type {{ invalidate: () => void }[]} */
+    const invalidating = [];
 
-    if (filledContext.watching) {
-      filledContext.watching.invalidate();
-      return;
-    }
-
-    // For plugin usage the host (webpack-cli, webpack-dev-server, etc.) owns
-    // `compiler.watch()`, so invalidate the host's `watching` instead
-    const { compiler: contextCompiler } = filledContext;
-
-    let invalidated = false;
-
-    if (contextCompiler.watching) {
-      contextCompiler.watching.invalidate();
-      invalidated = true;
+    if (watching) {
+      invalidating.push(watching);
+    } else if (contextCompiler.watching) {
+      // For plugin usage the host (webpack-cli, webpack-dev-server, etc.) owns
+      // `compiler.watch()`, so invalidate the host's `watching` instead
+      invalidating.push(contextCompiler.watching);
     } else if (isMultipleCompiler(contextCompiler)) {
       // `MultiCompiler` exposes `watching` only since webpack 5.109, fall back
       // to each child compiler's own `watching`
       for (const childCompiler of contextCompiler.compilers) {
         if (childCompiler.watching) {
-          childCompiler.watching.invalidate();
-          invalidated = true;
+          invalidating.push(childCompiler.watching);
         }
       }
     }
 
-    if (!invalidated) {
+    if (invalidating.length === 0) {
       filledContext.logger.warn(
         "The `invalidate` method was called, but the compiler is not watching, so there is nothing to invalidate.",
       );
+      // No stats to hand over: unlike `close`, this callback takes the build
+      // result, and no build ran.
+      callback();
+      return;
+    }
+
+    middleware.ready(filledContext, callback);
+
+    for (const target of invalidating) {
+      target.invalidate();
     }
   };
 

--- a/test/__snapshots__/pluginMode.test.js.snap.webpack5
+++ b/test/__snapshots__/pluginMode.test.js.snap.webpack5
@@ -3,3 +3,5 @@
 exports[`plugin mode close method should not close the watching owned by the host: warning 1`] = `"The \`close\` method was called, but there is no own \`watching\` instance to close. When using the middleware as a plugin, the host owns watching, so use \`compiler.close()\` instead."`;
 
 exports[`plugin mode close method should not throw and call the callback when the host is not watching: warning 1`] = `"The \`close\` method was called, but there is no own \`watching\` instance to close. When using the middleware as a plugin, the host owns watching, so use \`compiler.close()\` instead."`;
+
+exports[`plugin mode invalidate method should not throw and warn when the host is not watching: warning 1`] = `"The \`invalidate\` method was called, but the compiler is not watching, so there is nothing to invalidate."`;

--- a/test/pluginMode.test.js
+++ b/test/pluginMode.test.js
@@ -1,5 +1,6 @@
 import middleware from "../src";
 
+import webpackArrayConfig from "./fixtures/webpack.array.config";
 import webpackConfig from "./fixtures/webpack.config";
 import getCompiler from "./helpers/getCompiler";
 
@@ -23,6 +24,84 @@ describe("plugin mode", () => {
 
         watching.close(done);
       });
+    });
+
+    it("should call the callback after the host's rebuild finishes", (done) => {
+      const compiler = getCompiler(webpackConfig);
+      const watching = compiler.watch({}, () => {});
+      const instance = middleware(compiler, {}, true);
+
+      instance.waitUntilValid(() => {
+        instance.invalidate(() => {
+          expect(instance.context.state).toBe(true);
+
+          watching.close(done);
+        });
+      });
+    });
+
+    it("should invalidate the host's watching for a MultiCompiler", (done) => {
+      const compiler = getCompiler(webpackArrayConfig);
+      const watching = compiler.watch({}, () => {});
+      const instance = middleware(compiler, {}, true);
+      const invalidateSpy = jest.spyOn(watching, "invalidate");
+      const childSpies = compiler.compilers.map((childCompiler) =>
+        jest.spyOn(childCompiler.watching, "invalidate"),
+      );
+
+      instance.waitUntilValid(() => {
+        instance.invalidate();
+
+        expect(invalidateSpy).toHaveBeenCalledTimes(1);
+        // The `MultiCompiler`'s own watching propagates to every child, so
+        // each is invalidated exactly once — the fallback loop must not run
+        // as well and invalidate them a second time.
+        for (const childSpy of childSpies) {
+          expect(childSpy).toHaveBeenCalledTimes(1);
+        }
+
+        watching.close(done);
+      });
+    });
+
+    it("should invalidate each child's watching when a MultiCompiler has none", (done) => {
+      const compiler = getCompiler(webpackArrayConfig);
+      const watching = compiler.watch({}, () => {});
+      const instance = middleware(compiler, {}, true);
+      const childSpies = compiler.compilers.map((childCompiler) =>
+        jest.spyOn(childCompiler.watching, "invalidate"),
+      );
+
+      instance.waitUntilValid(() => {
+        // `MultiCompiler` only exposes `watching` since webpack 5.109; on
+        // older versions it lives on each child alone.
+        const ownWatching = compiler.watching;
+
+        compiler.watching = undefined;
+
+        instance.invalidate();
+
+        for (const childSpy of childSpies) {
+          expect(childSpy).toHaveBeenCalledTimes(1);
+        }
+
+        compiler.watching = ownWatching;
+
+        watching.close(done);
+      });
+    });
+
+    it("should warn when a MultiCompiler has no watching anywhere", () => {
+      const compiler = getCompiler(webpackArrayConfig);
+      const instance = middleware(compiler, {}, true);
+      const warnSpy = jest
+        .spyOn(instance.context.logger, "warn")
+        .mockImplementation();
+
+      expect(() => {
+        instance.invalidate();
+      }).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
     });
 
     it("should not throw and warn when the host is not watching", () => {

--- a/test/pluginMode.test.js
+++ b/test/pluginMode.test.js
@@ -9,6 +9,37 @@ jest.spyOn(globalThis.console, "log").mockImplementation();
 // webpack-dev-server, etc.) owns `compiler.watch()`, so the middleware has no
 // `watching` of its own
 describe("plugin mode", () => {
+  describe("invalidate method", () => {
+    it("should invalidate the watching owned by the host", (done) => {
+      const compiler = getCompiler(webpackConfig);
+      const watching = compiler.watch({}, () => {});
+      const instance = middleware(compiler, {}, true);
+      const invalidateSpy = jest.spyOn(watching, "invalidate");
+
+      instance.waitUntilValid(() => {
+        instance.invalidate();
+
+        expect(invalidateSpy).toHaveBeenCalledTimes(1);
+
+        watching.close(done);
+      });
+    });
+
+    it("should not throw and warn when the host is not watching", () => {
+      const compiler = getCompiler(webpackConfig);
+      const instance = middleware(compiler, {}, true);
+      const warnSpy = jest
+        .spyOn(instance.context.logger, "warn")
+        .mockImplementation();
+
+      expect(() => {
+        instance.invalidate();
+      }).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toMatchSnapshot("warning");
+    });
+  });
+
   describe("close method", () => {
     it("should not throw and call the callback when the host is not watching", (done) => {
       const compiler = getCompiler(webpackConfig);

--- a/test/pluginMode.test.js
+++ b/test/pluginMode.test.js
@@ -91,6 +91,22 @@ describe("plugin mode", () => {
       });
     });
 
+    it("should call the callback when there is nothing to invalidate", (done) => {
+      const compiler = getCompiler(webpackConfig);
+      const instance = middleware(compiler, {}, true);
+
+      jest.spyOn(instance.context.logger, "warn").mockImplementation();
+
+      // `close` completes its callback on the same no-op path. Without this,
+      // `ready` queues the callback against a build that will never run.
+      instance.invalidate((stats) => {
+        // No build ran, so there are no stats to report.
+        expect(stats).toBeUndefined();
+
+        done();
+      });
+    });
+
     it("should warn when a MultiCompiler has no watching anywhere", () => {
       const compiler = getCompiler(webpackArrayConfig);
       const instance = middleware(compiler, {}, true);


### PR DESCRIPTION
When used as a plugin the host (webpack-cli, webpack-dev-server, etc.) owns `compiler.watch()`, so `invalidate()` threw because the middleware has no `watching` of its own. Invalidate the host's `watching` instead (each child compiler's one for a `MultiCompiler` on webpack < 5.109) and warn when the compiler is not watching at all.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted fix to public `invalidate()` behavior in plugin mode with tests; standalone path unchanged when middleware owns `watching`.
> 
> **Overview**
> **Fixes a crash** when `invalidate()` is called while webpack-dev-middleware runs as a plugin (`isPlugin = true`), where the middleware no longer owns a `watching` instance.
> 
> `invalidate()` now uses the middleware’s own `watching` when present (standalone usage). In plugin mode it forwards invalidation to the host’s `compiler.watching`, or to each child compiler’s `watching` on `MultiCompiler` when top-level `watching` is missing (webpack &lt; 5.109). If nothing is watching, it **logs a warning** instead of throwing—aligned with existing plugin-mode `close()` behavior.
> 
> Plugin-mode tests cover host-owned invalidation and the no-watch warning; a changeset records the patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c801900ebb95fc32c7ad64e7e4f8c197638374df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plugin-mode invalidation so rebuilds correctly trigger through the host compiler.
  * Improved invalidation for multi-compiler setups, including configurations where individual child compilers are watched.
  * Prevented crashes when no compilation is being watched; a warning is now shown and the callback completes safely.
  * Ensured callbacks run after the relevant host or child compiler rebuild completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->