### PR TITLE
ci: open the release pull request as the app so it gets CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,17 @@ jobs:
     outputs:
       published: ${{ steps.changesets.outputs.published }}
     steps:
+      # A pull request opened with the repository's own GITHUB_TOKEN does not
+      # trigger workflows, so the release pull request never gets CI and sits
+      # with no checks reported. Opening it as the app makes the tests, lint
+      # and client jobs run on the version bump before it is merged.
+      - name: Generate Token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Use Node.js
@@ -34,12 +45,16 @@ jobs:
         id: changesets
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
+          # v2 takes a custom token through this input; the GITHUB_TOKEN
+          # environment variable is no longer read for the action's own auth.
+          github-token: ${{ steps.app-token.outputs.token }}
           version-script: npm run version
           publish-script: npm run release
           commit-message: "chore(release): new release"
           pr-title: "chore(release): new release"
         env:
-          # v2 no longer reads this for its own auth, but `changeset version`
-          # runs the changelog generator, which needs it to query GitHub.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Still needed as an environment variable: `changeset version` runs
+          # the changelog generator, which queries GitHub for commit and pull
+          # request info.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: "" # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+          # Without these the token carries every permission the app is
+          # installed with. These two are what changesets/action documents it
+          # needs: commit the version change, and open the pull request.
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

A pull request opened with the repository's own `GITHUB_TOKEN` does not trigger workflows. That is why #2393 has only the two Socket checks on it and no `Lint`, `Test` or `Client` job at all — the version bump and changelog reach `main` without the suite ever running on them, and with no checks reported the pull request cannot be merged.

The repository already generates an app token for the dependabot auto-merge workflow. The release job now does the same and hands it to `changesets/action`, which in v2 takes a custom token through the `github-token` input rather than the environment variable. `GITHUB_TOKEN` stays set in `env` because `changeset version` runs the changelog generator, which queries the GitHub API for commit and pull request info.

Effect on #2393: the next release-workflow run updates that pull request as the app, which triggers the workflows on it. Same secrets as `dependabot.yml` (`BOT_APP_ID` / `BOT_PRIVATE_KEY`), so nothing new needs configuring.

**What kind of change does this PR introduce?**

ci

**Did you add tests for your changes?**

No — workflow change; verified by parsing the workflow and checking `github-token` against the pinned action's own `action.yml`.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI was used. Claude Code diagnosed why the release pull request had no checks, wrote the workflow change, and drafted this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUpsHWHZG2FxHzJxRUvVv3

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUpsHWHZG2FxHzJxRUvVv3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated release automation to use dedicated application authentication when publishing changesets and retrieving changelog information.
  - Release workflows now use configured application credentials instead of the default repository token.
  - Restricted release automation permissions to the access required for publishing updates and managing pull requests, improving control over automated release activities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->