### PR TITLE
fix: bound the internal url and Range header caches

### DIFF
--- a/.changeset/bound-memoize-caches.md
+++ b/.changeset/bound-memoize-caches.md
@@ -1,0 +1,5 @@
+---
+"webpack-dev-middleware": patch
+---
+
+Bound the internal url and `Range` header caches, which grew for the life of the process and were never released, even by `close()`.

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -54,12 +54,13 @@ function decode(input) {
   return querystring.unescape(input);
 }
 
-const memoizedParse = memorize((url) => {
-  const urlObject = new URL(url, "http://localhost");
-
-  // We can't change pathname in URL object directly because don't decode correctly
-  return { ...urlObject, pathname: decode(urlObject.pathname) };
-}, undefined);
+// Only the pathname is ever read, and a `URL` cannot be carried around by
+// spreading it — its properties live on the prototype, so `{ ...url }` copies
+// nothing. The decoded pathname is returned on its own instead.
+const memoizedParsePathname = memorize((url) =>
+  // `URL` does not decode the pathname the way we need it.
+  decode(new URL(url, "http://localhost").pathname),
+);
 
 const UP_PATH_REGEXP = /(?:^|[\\/])\.\.(?:[\\/]|$)/;
 
@@ -117,12 +118,13 @@ function isNotFoundError(error) {
  * @returns {Promise<FilenameWithExtra | undefined>} result of get filename from url
  */
 async function getFilenameFromUrl(context, url) {
-  /** @type {URL} */
-  let urlObject;
+  /** @type {string} */
+  let pathname;
 
   try {
-    // The `url` property of the `request` is contains only  `pathname`, `search` and `hash`
-    urlObject = memoizedParse(url);
+    // The `url` property of the `request` contains only `pathname`, `search`
+    // and `hash`.
+    pathname = memoizedParsePathname(url);
   } catch {
     return;
   }
@@ -146,22 +148,19 @@ async function getFilenameFromUrl(context, url) {
       continue;
     }
 
-    /** @type {URL} */
-    let publicPathObject;
+    /** @type {string} */
+    let publicPathPathname;
 
     const publicPath =
       options.publicPath || compilation.options.output.publicPath || "";
 
     try {
-      publicPathObject = memoizedParse(
+      publicPathPathname = memoizedParsePathname(
         publicPath === "auto" ? "/" : compilation.getPath(publicPath),
       );
     } catch {
       continue;
     }
-
-    const { pathname } = urlObject;
-    const { pathname: publicPathPathname } = publicPathObject;
 
     /** @type {string | undefined} */
     let filename;

--- a/src/utils.js
+++ b/src/utils.js
@@ -169,14 +169,24 @@ const cacheStore = new WeakMap();
  * @typedef {(...args: EXPECTED_ANY) => T} FunctionReturning
  */
 
+// These caches are keyed by request data — a url, or a `Range` header — so
+// the key space is only as bounded as what clients send. Without a limit a
+// long-running server keeps every key it has ever seen, so the cache is an
+// LRU: enough to serve a project's assets, capped for everything else.
+const DEFAULT_MAX_CACHE_SIZE = 1000;
+
 /**
  * @template T
  * @param {FunctionReturning<T>} fn memorized function
- * @param {({ cache?: Map<string, { data: T }> } | undefined)=} cache cache
+ * @param {({ cache?: Map<string, { data: T }>, maxSize?: number } | undefined)=} cache cache
  * @param {((value: T) => T)=} callback callback
  * @returns {FunctionReturning<T>} new function
  */
-function memorize(fn, { cache = new Map() } = {}, callback = undefined) {
+function memorize(
+  fn,
+  { cache = new Map(), maxSize = DEFAULT_MAX_CACHE_SIZE } = {},
+  callback = undefined,
+) {
   /**
    * @param {EXPECTED_ANY[]} arguments_ args
    * @returns {EXPECTED_ANY} result
@@ -186,6 +196,11 @@ function memorize(fn, { cache = new Map() } = {}, callback = undefined) {
     const cacheItem = cache.get(key);
 
     if (cacheItem) {
+      // Re-inserting moves the key to the end of the map's insertion order,
+      // which is what makes the first key the least recently used one.
+      cache.delete(key);
+      cache.set(key, cacheItem);
+
       return cacheItem.data;
     }
 
@@ -194,6 +209,10 @@ function memorize(fn, { cache = new Map() } = {}, callback = undefined) {
 
     if (callback) {
       result = callback(result);
+    }
+
+    if (cache.size >= maxSize) {
+      cache.delete(/** @type {string} */ (cache.keys().next().value));
     }
 
     cache.set(key, {

--- a/src/utils.js
+++ b/src/utils.js
@@ -181,12 +181,18 @@ const DEFAULT_MAX_CACHE_SIZE = 1000;
  * @param {({ cache?: Map<string, { data: T }>, maxSize?: number } | undefined)=} cache cache
  * @param {((value: T) => T)=} callback callback
  * @returns {FunctionReturning<T>} new function
+ * @throws {TypeError} when `maxSize` is not a positive integer
  */
 function memorize(
   fn,
   { cache = new Map(), maxSize = DEFAULT_MAX_CACHE_SIZE } = {},
   callback = undefined,
 ) {
+  // A non-positive or fractional limit would never evict, or never terminate below.
+  if (!Number.isInteger(maxSize) || maxSize < 1) {
+    throw new TypeError("The 'maxSize' option must be a positive integer.");
+  }
+
   /**
    * @param {EXPECTED_ANY[]} arguments_ args
    * @returns {EXPECTED_ANY} result
@@ -211,7 +217,8 @@ function memorize(
       result = callback(result);
     }
 
-    if (cache.size >= maxSize) {
+    // A loop, because a caller-supplied cache can start out over the limit.
+    while (cache.size >= maxSize) {
       cache.delete(/** @type {string} */ (cache.keys().next().value));
     }
 

--- a/test/utils/memorize.test.js
+++ b/test/utils/memorize.test.js
@@ -1,0 +1,59 @@
+import { memorize } from "../../src/utils.js";
+
+describe("memorize", () => {
+  it("should call the function once per key", () => {
+    const fn = jest.fn((value) => `${value}!`);
+    const memoized = memorize(fn);
+
+    expect(memoized("a")).toBe("a!");
+    expect(memoized("a")).toBe("a!");
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("should apply the callback to the value it stores", () => {
+    const memoized = memorize(
+      (value) => value,
+      undefined,
+      (value) => `${value}-mapped`,
+    );
+
+    expect(memoized("a")).toBe("a-mapped");
+    expect(memoized("a")).toBe("a-mapped");
+  });
+
+  it("should not grow past the cache limit", () => {
+    const cache = new Map();
+    const memoized = memorize((value) => value, { cache, maxSize: 3 });
+
+    for (let i = 0; i < 100; i++) {
+      memoized(`key-${i}`);
+    }
+
+    // Without a limit this cache would hold every key the process ever saw;
+    // these are keyed by request data, so that grows with traffic.
+    expect(cache.size).toBeLessThanOrEqual(3);
+  });
+
+  it("should evict the least recently used key", () => {
+    const fn = jest.fn((value) => value);
+    const cache = new Map();
+    const memoized = memorize(fn, { cache, maxSize: 2 });
+
+    memoized("a");
+    memoized("b");
+    // Reading "a" makes "b" the least recently used one.
+    memoized("a");
+    memoized("c");
+
+    expect([...cache.keys()]).toEqual(["a", "c"]);
+
+    // "a" survived, so it is still a hit; "b" was evicted and recomputes.
+    fn.mockClear();
+    memoized("a");
+    expect(fn).not.toHaveBeenCalled();
+
+    memoized("b");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/utils/memorize.test.js
+++ b/test/utils/memorize.test.js
@@ -35,6 +35,28 @@ describe("memorize", () => {
     expect(cache.size).toBeLessThanOrEqual(3);
   });
 
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    "should reject the '%s' cache limit",
+    (maxSize) => {
+      expect(() => memorize((value) => value, { maxSize })).toThrow(
+        /must be a positive integer/,
+      );
+    },
+  );
+
+  it("should bring a cache that is already over the limit back down", () => {
+    const cache = new Map([
+      ["a", { data: "a" }],
+      ["b", { data: "b" }],
+      ["c", { data: "c" }],
+    ]);
+    const memoized = memorize((value) => value, { cache, maxSize: 2 });
+
+    memoized("d");
+
+    expect([...cache.keys()]).toEqual(["c", "d"]);
+  });
+
   it("should evict the least recently used key", () => {
     const fn = jest.fn((value) => value);
     const cache = new Map();

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -242,6 +242,7 @@ export function initState<
  * @param {({ cache?: Map<string, { data: T }>, maxSize?: number } | undefined)=} cache cache
  * @param {((value: T) => T)=} callback callback
  * @returns {FunctionReturning<T>} new function
+ * @throws {TypeError} when `maxSize` is not a positive integer
  */
 export function memorize<T>(
   fn: FunctionReturning<T>,

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -1,6 +1,5 @@
 export type Stats = import("fs").Stats;
 export type ReadStream = import("fs").ReadStream;
-export type FunctionReturning<T> = (...args: EXPECTED_ANY) => T;
 export type ExpectedIncomingMessage = {
   /**
    * get header extra method
@@ -82,6 +81,7 @@ export type IncomingMessage = import("./index").IncomingMessage;
 export type ServerResponse = import("./index").ServerResponse;
 export type OutputFileSystem = import("./index").OutputFileSystem;
 export type EXPECTED_ANY = import("./index").EXPECTED_ANY;
+export type FunctionReturning<T> = (...args: EXPECTED_ANY) => T;
 /**
  * @param {string} filename filename
  * @param {OutputFileSystem} outputFileSystem output file system
@@ -238,12 +238,8 @@ export function initState<
 >(res: Response): void;
 /**
  * @template T
- * @typedef {(...args: EXPECTED_ANY) => T} FunctionReturning
- */
-/**
- * @template T
  * @param {FunctionReturning<T>} fn memorized function
- * @param {({ cache?: Map<string, { data: T }> } | undefined)=} cache cache
+ * @param {({ cache?: Map<string, { data: T }>, maxSize?: number } | undefined)=} cache cache
  * @param {((value: T) => T)=} callback callback
  * @returns {FunctionReturning<T>} new function
  */
@@ -251,6 +247,7 @@ export function memorize<T>(
   fn: FunctionReturning<T>,
   {
     cache,
+    maxSize,
   }?:
     | (
         | {
@@ -260,6 +257,7 @@ export function memorize<T>(
                 data: T;
               }
             >;
+            maxSize?: number;
           }
         | undefined
       )


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`memorize()` backs two module-level caches that were never evicted: `memoizedParse`, keyed by request url, and `parseRangeHeaders`, keyed by `size` plus the `Range` header. Their keys come from request data — and in the second case from a header the client chooses — so the key space is not bounded by anything the server controls. Being module-level, they also outlived the middleware instance.

Measured against a fixture project, before and after:

| | before | after |
| --- | --- | --- |
| 50,000 distinct urls | 9.24 MB retained (9.18 MB of it surviving `instance.close()`) | 0.37 MB |
| 20,000 distinct `Range` headers | 4.70 MB retained | bounded — the remainder is fixed http overhead and does not grow with N (1.61 MB at 10k, 1.62 MB at 20k, noise at 40k) |

The cache now keeps a fixed number of entries and drops the least recently used one, re-inserting on a hit so map insertion order tracks recency.

It also drops a spread that copied nothing: `{ ...urlObject }` on a `URL` yields an empty object, because a `URL`'s properties are prototype accessors. The value was therefore `{ pathname }` while being annotated `@type {URL}` — reading `.search` off it would have type-checked and been `undefined` at runtime. Only the pathname was ever used, so it is returned on its own.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/utils/memorize.test.js` covers the hit path, the callback, that the cache stops growing, and that the evicted key is the least recently used one.

**Does this PR introduce a breaking change?**

No. `memorize()` is internal, and the cache limit is an option with a default.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI was used. Claude Code found the caches while reviewing for memory issues, measured the retention before and after with `--expose-gc`, wrote the fix and its tests, and drafted this description. Every number above comes from running those measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUpsHWHZG2FxHzJxRUvVv3

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUpsHWHZG2FxHzJxRUvVv3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented URL and HTTP range caches from growing indefinitely.
  * Cached data is now released when the development middleware is closed.
  * Added least-recently-used eviction to maintain bounded caches.

* **Performance**
  * Improved repeated URL and file-path processing through more efficient pathname caching.
  * Added safeguards for predictable memory usage during extended development sessions.

* **Documentation**
  * Documented configurable cache size limits and validation for invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->